### PR TITLE
Clarify z-order semantics in ppt_list_shapes docstring

### DIFF
--- a/src/ppt_com/shapes.py
+++ b/src/ppt_com/shapes.py
@@ -581,6 +581,8 @@ def list_shapes(params: ListShapesInput) -> str:
 
     Returns an array of shapes with their name, id, type, position, size,
     and a text preview (first 50 characters) for shapes that contain text.
+    The index field reflects z-order (stacking order): index 1 is the
+    backmost shape, the highest index is the frontmost shape.
 
     Args:
         params: Slide index to list shapes from.


### PR DESCRIPTION
## Summary

- `ppt_list_shapes` の `index` フィールドが z-order 順（1=最背面）であることを docstring に明記
- 同じ値の `z_order` フィールドを追加する代わりに、既存の `index` の意味を説明する方針に変更

## Closes

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)