### PR TITLE
Add best practice hints to shape identifier field descriptions

### DIFF
--- a/src/ppt_com/advanced_ops.py
+++ b/src/ppt_com/advanced_ops.py
@@ -177,7 +177,7 @@ class SetTagInput(BaseModel):
         default=None, ge=1, description="1-based slide index (required for slide/shape targets)"
     )
     shape_name_or_index: Optional[Union[str, int]] = Field(
-        default=None, description="Shape name (str) or 1-based index (int) for shape target"
+        default=None, description="Shape name (str) or 1-based index (int) for shape target. Prefer name — indices shift when shapes are added/removed"
     )
     tag_name: str = Field(..., description="Tag name (key)")
     tag_value: str = Field(..., description="Tag value")
@@ -195,7 +195,7 @@ class GetTagsInput(BaseModel):
         default=None, ge=1, description="1-based slide index (required for slide/shape targets)"
     )
     shape_name_or_index: Optional[Union[str, int]] = Field(
-        default=None, description="Shape name (str) or 1-based index (int) for shape target"
+        default=None, description="Shape name (str) or 1-based index (int) for shape target. Prefer name — indices shift when shapes are added/removed"
     )
     target_type: str = Field(
         default="shape",
@@ -219,7 +219,7 @@ class CropPictureInput(BaseModel):
 
     slide_index: int = Field(..., ge=1, description="1-based slide index")
     shape_name_or_index: Union[str, int] = Field(
-        ..., description="Shape name (str) or 1-based index (int)"
+        ..., description="Shape name (str) or 1-based index (int). Prefer name — indices shift when shapes are added/removed"
     )
     crop_left: Optional[float] = Field(default=None, description="Crop from left in points")
     crop_right: Optional[float] = Field(default=None, description="Crop from right in points")
@@ -234,7 +234,7 @@ class ExportShapeInput(BaseModel):
 
     slide_index: int = Field(..., ge=1, description="1-based slide index")
     shape_name_or_index: Union[str, int] = Field(
-        ..., description="Shape name (str) or 1-based index (int)"
+        ..., description="Shape name (str) or 1-based index (int). Prefer name — indices shift when shapes are added/removed"
     )
     file_path: str = Field(..., description="Output file path")
     format: str = Field(
@@ -289,10 +289,10 @@ class CopyAnimationInput(BaseModel):
 
     slide_index: int = Field(..., ge=1, description="1-based slide index")
     source_shape: Union[str, int] = Field(
-        ..., description="Source shape name (str) or 1-based index (int)"
+        ..., description="Source shape name (str) or 1-based index (int). Prefer name — indices shift when shapes are added/removed"
     )
     target_shape: Union[str, int] = Field(
-        ..., description="Target shape name (str) or 1-based index (int)"
+        ..., description="Target shape name (str) or 1-based index (int). Prefer name — indices shift when shapes are added/removed"
     )
 
 
@@ -366,7 +366,7 @@ class LockAspectRatioInput(BaseModel):
 
     slide_index: int = Field(..., ge=1, description="1-based slide index")
     shape_name_or_index: Union[str, int] = Field(
-        ..., description="Shape name (str) or 1-based index (int)"
+        ..., description="Shape name (str) or 1-based index (int). Prefer name — indices shift when shapes are added/removed"
     )
     locked: bool = Field(..., description="True to lock, False to unlock")
 

--- a/src/ppt_com/animation.py
+++ b/src/ppt_com/animation.py
@@ -82,7 +82,7 @@ class AddAnimationInput(BaseModel):
 
     slide_index: int = Field(..., ge=1, description="1-based slide index")
     shape_name_or_index: Union[str, int] = Field(
-        ..., description="Shape name (string) or 1-based index (int)"
+        ..., description="Shape name (str) or 1-based index (int). Prefer name — indices shift when shapes are added/removed"
     )
     effect: Union[int, str] = Field(
         default="appear",

--- a/src/ppt_com/charts.py
+++ b/src/ppt_com/charts.py
@@ -72,7 +72,7 @@ class SetChartDataInput(BaseModel):
 
     slide_index: int = Field(..., ge=1, description="1-based slide index")
     shape_name_or_index: Union[str, int] = Field(
-        ..., description="Chart shape name (string) or 1-based index (int)"
+        ..., description="Chart shape name (str) or 1-based index (int). Prefer name — indices shift when shapes are added/removed"
     )
     categories: list[str] = Field(
         ..., description="List of category labels (e.g. ['Q1', 'Q2', 'Q3', 'Q4'])"
@@ -92,7 +92,7 @@ class GetChartDataInput(BaseModel):
 
     slide_index: int = Field(..., ge=1, description="1-based slide index")
     shape_name_or_index: Union[str, int] = Field(
-        ..., description="Chart shape name (string) or 1-based index (int)"
+        ..., description="Chart shape name (str) or 1-based index (int). Prefer name — indices shift when shapes are added/removed"
     )
 
 
@@ -102,7 +102,7 @@ class FormatChartInput(BaseModel):
 
     slide_index: int = Field(..., ge=1, description="1-based slide index")
     shape_name_or_index: Union[str, int] = Field(
-        ..., description="Chart shape name (string) or 1-based index (int)"
+        ..., description="Chart shape name (str) or 1-based index (int). Prefer name — indices shift when shapes are added/removed"
     )
     title: Optional[str] = Field(
         default=None, description="Chart title text (sets HasTitle=True automatically)"
@@ -125,7 +125,7 @@ class SetChartSeriesInput(BaseModel):
 
     slide_index: int = Field(..., ge=1, description="1-based slide index")
     shape_name_or_index: Union[str, int] = Field(
-        ..., description="Chart shape name (string) or 1-based index (int)"
+        ..., description="Chart shape name (str) or 1-based index (int). Prefer name — indices shift when shapes are added/removed"
     )
     series_index: int = Field(..., ge=1, description="1-based series index")
     color: Optional[str] = Field(
@@ -145,7 +145,7 @@ class ChangeChartTypeInput(BaseModel):
 
     slide_index: int = Field(..., ge=1, description="1-based slide index")
     shape_name_or_index: Union[str, int] = Field(
-        ..., description="Chart shape name (string) or 1-based index (int)"
+        ..., description="Chart shape name (str) or 1-based index (int). Prefer name — indices shift when shapes are added/removed"
     )
     chart_type: Union[int, str] = Field(
         ...,

--- a/src/ppt_com/connectors.py
+++ b/src/ppt_com/connectors.py
@@ -84,7 +84,7 @@ class FormatConnectorInput(BaseModel):
 
     slide_index: int = Field(..., ge=1, description="1-based slide index")
     shape_name_or_index: Union[str, int] = Field(
-        ..., description="Connector shape name (string) or 1-based index (int)"
+        ..., description="Connector shape name (str) or 1-based index (int). Prefer name — indices shift when shapes are added/removed"
     )
     color: Optional[str] = Field(
         default=None, description="Line color as '#RRGGBB'"

--- a/src/ppt_com/edit_ops.py
+++ b/src/ppt_com/edit_ops.py
@@ -45,7 +45,7 @@ class CopyShapeToSlideInput(BaseModel):
 
     src_slide_index: int = Field(..., ge=1, description="1-based source slide index")
     shape_name_or_index: Union[str, int] = Field(
-        ..., description="Shape name (string) or 1-based index (int) on the source slide"
+        ..., description="Shape name (str) or 1-based index (int) on the source slide. Prefer name — indices shift when shapes are added/removed"
     )
     dst_slide_index: int = Field(..., ge=1, description="1-based destination slide index")
 
@@ -56,7 +56,7 @@ class CopyFormattingInput(BaseModel):
 
     slide_index: int = Field(..., ge=1, description="1-based slide index")
     source_shape: Union[str, int] = Field(
-        ..., description="Source shape name (string) or 1-based index (int)"
+        ..., description="Source shape name (str) or 1-based index (int). Prefer name — indices shift when shapes are added/removed"
     )
     target_shapes: list[Union[str, int]] = Field(
         ..., min_length=1,

--- a/src/ppt_com/effects.py
+++ b/src/ppt_com/effects.py
@@ -45,7 +45,7 @@ class SetGlowInput(BaseModel):
 
     slide_index: int = Field(..., ge=1, description="1-based slide index")
     shape_name_or_index: Union[str, int] = Field(
-        ..., description="Shape name (string) or 1-based index (int)"
+        ..., description="Shape name (str) or 1-based index (int). Prefer name — indices shift when shapes are added/removed"
     )
     radius: float = Field(
         ..., ge=0, description="Glow radius in points (0 to remove glow)"
@@ -65,7 +65,7 @@ class SetReflectionInput(BaseModel):
 
     slide_index: int = Field(..., ge=1, description="1-based slide index")
     shape_name_or_index: Union[str, int] = Field(
-        ..., description="Shape name (string) or 1-based index (int)"
+        ..., description="Shape name (str) or 1-based index (int). Prefer name — indices shift when shapes are added/removed"
     )
     reflection_type: Optional[int] = Field(
         default=None, ge=0, le=9,
@@ -93,7 +93,7 @@ class SetSoftEdgeInput(BaseModel):
 
     slide_index: int = Field(..., ge=1, description="1-based slide index")
     shape_name_or_index: Union[str, int] = Field(
-        ..., description="Shape name (string) or 1-based index (int)"
+        ..., description="Shape name (str) or 1-based index (int). Prefer name — indices shift when shapes are added/removed"
     )
     radius: float = Field(
         ..., ge=0, description="Soft edge radius in points (0 to remove)"

--- a/src/ppt_com/formatting.py
+++ b/src/ppt_com/formatting.py
@@ -72,7 +72,7 @@ class SetFillInput(BaseModel):
 
     slide_index: int = Field(..., description="1-based slide index")
     shape_name_or_index: Union[str, int] = Field(
-        ..., description="Shape name (string) or 1-based index (int)"
+        ..., description="Shape name (str) or 1-based index (int). Prefer name — indices shift when shapes are added/removed"
     )
     fill_type: str = Field(
         ..., description="'solid', 'gradient', or 'none'"
@@ -101,7 +101,7 @@ class SetLineInput(BaseModel):
 
     slide_index: int = Field(..., description="1-based slide index")
     shape_name_or_index: Union[str, int] = Field(
-        ..., description="Shape name (string) or 1-based index (int)"
+        ..., description="Shape name (str) or 1-based index (int). Prefer name — indices shift when shapes are added/removed"
     )
     color: Optional[str] = Field(default=None, description="Line color as '#RRGGBB'")
     weight: Optional[float] = Field(default=None, description="Line weight in points")
@@ -121,7 +121,7 @@ class SetShadowInput(BaseModel):
 
     slide_index: int = Field(..., description="1-based slide index")
     shape_name_or_index: Union[str, int] = Field(
-        ..., description="Shape name (string) or 1-based index (int)"
+        ..., description="Shape name (str) or 1-based index (int). Prefer name — indices shift when shapes are added/removed"
     )
     visible: bool = Field(..., description="Shadow visible on/off")
     blur: Optional[float] = Field(default=None, description="Shadow blur radius in points")

--- a/src/ppt_com/groups.py
+++ b/src/ppt_com/groups.py
@@ -37,7 +37,7 @@ class UngroupShapesInput(BaseModel):
 
     slide_index: int = Field(..., ge=1, description="1-based slide index")
     shape_name_or_index: Union[str, int] = Field(
-        ..., description="Group shape name (string) or 1-based index (int)"
+        ..., description="Group shape name (str) or 1-based index (int). Prefer name — indices shift when shapes are added/removed"
     )
 
 
@@ -47,7 +47,7 @@ class GetGroupItemsInput(BaseModel):
 
     slide_index: int = Field(..., ge=1, description="1-based slide index")
     shape_name_or_index: Union[str, int] = Field(
-        ..., description="Group shape name (string) or 1-based index (int)"
+        ..., description="Group shape name (str) or 1-based index (int). Prefer name — indices shift when shapes are added/removed"
     )
 
 

--- a/src/ppt_com/hyperlinks.py
+++ b/src/ppt_com/hyperlinks.py
@@ -34,7 +34,7 @@ class AddHyperlinkInput(BaseModel):
 
     slide_index: int = Field(..., ge=1, description="1-based slide index")
     shape_name_or_index: Union[str, int] = Field(
-        ..., description="Shape name (string) or 1-based index (int)"
+        ..., description="Shape name (str) or 1-based index (int). Prefer name — indices shift when shapes are added/removed"
     )
     address: str = Field(
         ..., description="Hyperlink URL, file path, or mailto: address"
@@ -65,7 +65,7 @@ class RemoveHyperlinkInput(BaseModel):
 
     slide_index: int = Field(..., ge=1, description="1-based slide index")
     shape_name_or_index: Union[str, int] = Field(
-        ..., description="Shape name (string) or 1-based index (int)"
+        ..., description="Shape name (str) or 1-based index (int). Prefer name — indices shift when shapes are added/removed"
     )
     action_on: str = Field(
         default="click",

--- a/src/ppt_com/layout.py
+++ b/src/ppt_com/layout.py
@@ -133,7 +133,7 @@ class FlipShapeInput(BaseModel):
 
     slide_index: int = Field(..., ge=1, description="1-based slide index")
     shape_name_or_index: Union[str, int] = Field(
-        ..., description="Shape name (string) or 1-based index (int)"
+        ..., description="Shape name (str) or 1-based index (int). Prefer name — indices shift when shapes are added/removed"
     )
     direction: str = Field(
         ...,

--- a/src/ppt_com/media.py
+++ b/src/ppt_com/media.py
@@ -59,7 +59,7 @@ class SetMediaSettingsInput(BaseModel):
 
     slide_index: int = Field(..., ge=1, description="1-based slide index")
     shape_name_or_index: Union[str, int] = Field(
-        ..., description="Media shape name (string) or 1-based index (int)"
+        ..., description="Media shape name (str) or 1-based index (int). Prefer name — indices shift when shapes are added/removed"
     )
     volume: Optional[float] = Field(
         default=None, ge=0.0, le=1.0,

--- a/src/ppt_com/shapes.py
+++ b/src/ppt_com/shapes.py
@@ -149,8 +149,8 @@ class ShapeIdentifierInput(BaseModel):
     model_config = ConfigDict(str_strip_whitespace=True)
 
     slide_index: int = Field(..., ge=1, description="1-based slide index")
-    shape_name: Optional[str] = Field(default=None, description="Shape name")
-    shape_index: Optional[int] = Field(default=None, ge=1, description="1-based shape index")
+    shape_name: Optional[str] = Field(default=None, description="Shape name (preferred — indices shift when shapes are added/removed)")
+    shape_index: Optional[int] = Field(default=None, ge=1, description="1-based shape index (unstable — prefer shape_name)")
 
 
 class UpdateShapeInput(BaseModel):
@@ -158,8 +158,8 @@ class UpdateShapeInput(BaseModel):
     model_config = ConfigDict(str_strip_whitespace=True)
 
     slide_index: int = Field(..., ge=1, description="1-based slide index")
-    shape_name: Optional[str] = Field(default=None, description="Shape name")
-    shape_index: Optional[int] = Field(default=None, ge=1, description="1-based shape index")
+    shape_name: Optional[str] = Field(default=None, description="Shape name (preferred — indices shift when shapes are added/removed)")
+    shape_index: Optional[int] = Field(default=None, ge=1, description="1-based shape index (unstable — prefer shape_name)")
     left: Optional[float] = Field(default=None, description="New left position in points")
     top: Optional[float] = Field(default=None, description="New top position in points")
     width: Optional[float] = Field(default=None, description="New width in points")
@@ -173,8 +173,8 @@ class SetZOrderInput(BaseModel):
     model_config = ConfigDict(str_strip_whitespace=True)
 
     slide_index: int = Field(..., ge=1, description="1-based slide index")
-    shape_name: Optional[str] = Field(default=None, description="Shape name")
-    shape_index: Optional[int] = Field(default=None, ge=1, description="1-based shape index")
+    shape_name: Optional[str] = Field(default=None, description="Shape name (preferred — indices shift when shapes are added/removed)")
+    shape_index: Optional[int] = Field(default=None, ge=1, description="1-based shape index (unstable — prefer shape_name)")
     command: str = Field(
         ...,
         description="Z-order command: 'bring_to_front', 'send_to_back', 'bring_forward', 'send_backward'",

--- a/src/ppt_com/smartart.py
+++ b/src/ppt_com/smartart.py
@@ -49,7 +49,7 @@ class ModifySmartArtInput(BaseModel):
 
     slide_index: int = Field(..., ge=1, description="1-based slide index")
     shape_name_or_index: Union[str, int] = Field(
-        ..., description="SmartArt shape name (string) or 1-based index (int)"
+        ..., description="SmartArt shape name (str) or 1-based index (int). Prefer name — indices shift when shapes are added/removed"
     )
     action: str = Field(
         ..., description="Action to perform: 'set_text', 'add_node', or 'delete_node'"

--- a/src/ppt_com/tables.py
+++ b/src/ppt_com/tables.py
@@ -49,7 +49,7 @@ class GetTableDataInput(BaseModel):
 
     slide_index: int = Field(..., ge=1, description="1-based slide index")
     shape_name_or_index: Union[str, int] = Field(
-        ..., description="Table shape name (string) or 1-based index (int)"
+        ..., description="Table shape name (str) or 1-based index (int). Prefer name — indices shift when shapes are added/removed"
     )
 
 
@@ -59,7 +59,7 @@ class SetTableCellInput(BaseModel):
 
     slide_index: int = Field(..., ge=1, description="1-based slide index")
     shape_name_or_index: Union[str, int] = Field(
-        ..., description="Table shape name (string) or 1-based index (int)"
+        ..., description="Table shape name (str) or 1-based index (int). Prefer name — indices shift when shapes are added/removed"
     )
     row: int = Field(..., ge=1, description="1-based row number")
     col: int = Field(..., ge=1, description="1-based column number")
@@ -81,7 +81,7 @@ class MergeTableCellsInput(BaseModel):
 
     slide_index: int = Field(..., ge=1, description="1-based slide index")
     shape_name_or_index: Union[str, int] = Field(
-        ..., description="Table shape name (string) or 1-based index (int)"
+        ..., description="Table shape name (str) or 1-based index (int). Prefer name — indices shift when shapes are added/removed"
     )
     start_row: int = Field(..., ge=1, description="Top-left cell row (1-based)")
     start_col: int = Field(..., ge=1, description="Top-left cell column (1-based)")
@@ -95,7 +95,7 @@ class TableRowInput(BaseModel):
 
     slide_index: int = Field(..., ge=1, description="1-based slide index")
     shape_name_or_index: Union[str, int] = Field(
-        ..., description="Table shape name (string) or 1-based index (int)"
+        ..., description="Table shape name (str) or 1-based index (int). Prefer name — indices shift when shapes are added/removed"
     )
     position: Optional[int] = Field(
         default=None, ge=1,
@@ -109,7 +109,7 @@ class TableColumnInput(BaseModel):
 
     slide_index: int = Field(..., ge=1, description="1-based slide index")
     shape_name_or_index: Union[str, int] = Field(
-        ..., description="Table shape name (string) or 1-based index (int)"
+        ..., description="Table shape name (str) or 1-based index (int). Prefer name — indices shift when shapes are added/removed"
     )
     position: Optional[int] = Field(
         default=None, ge=1,
@@ -123,7 +123,7 @@ class SetTableStyleInput(BaseModel):
 
     slide_index: int = Field(..., ge=1, description="1-based slide index")
     shape_name_or_index: Union[str, int] = Field(
-        ..., description="Table shape name (string) or 1-based index (int)"
+        ..., description="Table shape name (str) or 1-based index (int). Prefer name — indices shift when shapes are added/removed"
     )
     style_id: Optional[str] = Field(
         default=None,

--- a/src/ppt_com/text.py
+++ b/src/ppt_com/text.py
@@ -92,7 +92,7 @@ class SetTextInput(BaseModel):
 
     slide_index: int = Field(..., description="1-based slide index")
     shape_name_or_index: Union[str, int] = Field(
-        ..., description="Shape name (string) or 1-based index (int)"
+        ..., description="Shape name (str) or 1-based index (int). Prefer name — indices shift when shapes are added/removed"
     )
     text: str = Field(
         ...,
@@ -111,7 +111,7 @@ class GetTextInput(BaseModel):
 
     slide_index: int = Field(..., description="1-based slide index")
     shape_name_or_index: Union[str, int] = Field(
-        ..., description="Shape name (string) or 1-based index (int)"
+        ..., description="Shape name (str) or 1-based index (int). Prefer name — indices shift when shapes are added/removed"
     )
 
 
@@ -121,7 +121,7 @@ class FormatTextInput(BaseModel):
 
     slide_index: int = Field(..., description="1-based slide index")
     shape_name_or_index: Union[str, int] = Field(
-        ..., description="Shape name (string) or 1-based index (int)"
+        ..., description="Shape name (str) or 1-based index (int). Prefer name — indices shift when shapes are added/removed"
     )
     font_name: Optional[str] = Field(default=None, description="Font name (e.g. 'Arial')")
     font_size: Optional[float] = Field(default=None, description="Font size in points")
@@ -141,7 +141,7 @@ class FormatTextRangeInput(BaseModel):
 
     slide_index: int = Field(..., description="1-based slide index")
     shape_name_or_index: Union[str, int] = Field(
-        ..., description="Shape name (string) or 1-based index (int)"
+        ..., description="Shape name (str) or 1-based index (int). Prefer name — indices shift when shapes are added/removed"
     )
     start: int = Field(..., description="1-based character start position")
     length: int = Field(..., description="Number of characters to format")
@@ -163,7 +163,7 @@ class SetParagraphFormatInput(BaseModel):
 
     slide_index: int = Field(..., description="1-based slide index")
     shape_name_or_index: Union[str, int] = Field(
-        ..., description="Shape name (string) or 1-based index (int)"
+        ..., description="Shape name (str) or 1-based index (int). Prefer name — indices shift when shapes are added/removed"
     )
     paragraph_index: Optional[int] = Field(
         default=None, description="1-based paragraph index. Omit to format all paragraphs."
@@ -184,7 +184,7 @@ class SetBulletInput(BaseModel):
 
     slide_index: int = Field(..., description="1-based slide index")
     shape_name_or_index: Union[str, int] = Field(
-        ..., description="Shape name (string) or 1-based index (int)"
+        ..., description="Shape name (str) or 1-based index (int). Prefer name — indices shift when shapes are added/removed"
     )
     paragraph_index: Optional[int] = Field(
         default=None, description="1-based paragraph index. Omit to set for all paragraphs."
@@ -217,7 +217,7 @@ class SetTextframeInput(BaseModel):
 
     slide_index: int = Field(..., description="1-based slide index")
     shape_name_or_index: Union[str, int] = Field(
-        ..., description="Shape name (string) or 1-based index (int)"
+        ..., description="Shape name (str) or 1-based index (int). Prefer name — indices shift when shapes are added/removed"
     )
     auto_size: Optional[str] = Field(
         default=None,


### PR DESCRIPTION
## Summary

- 15モジュールの全 `shape_name_or_index` Field description に「Prefer name — indices shift when shapes are added/removed」を追記
- `shapes.py` の分離フィールド（`shape_name` / `shape_index`）にも同様の推奨・警告を追記
- AI エージェントが JSON スキーマから自然にベストプラクティスを読み取れるようになる

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)