### PR TITLE
Fix batch_apply: normalize shape identifiers with str_strip_whitespace

### DIFF
--- a/src/ppt_com/batch_apply.py
+++ b/src/ppt_com/batch_apply.py
@@ -4,7 +4,7 @@ import json
 import logging
 from typing import Any, List, Optional, Union
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ConfigDict
 
 from utils.com_wrapper import ppt
 
@@ -58,6 +58,8 @@ def _get_shape(slide, name_or_index):
 
 class BatchOperation(BaseModel):
     """A single formatting operation to apply."""
+    model_config = ConfigDict(str_strip_whitespace=True)
+
     tool: str = Field(
         ...,
         description=(
@@ -73,6 +75,8 @@ class BatchOperation(BaseModel):
 
 class BatchApplyFormattingInput(BaseModel):
     """Input for batch applying formatting to multiple shapes."""
+    model_config = ConfigDict(str_strip_whitespace=True)
+
     slide_index: int = Field(..., ge=1, description="1-based slide index")
     shapes: List[Union[str, int]] = Field(
         ...,


### PR DESCRIPTION
## Summary

- Add `model_config = ConfigDict(str_strip_whitespace=True)` to `BatchOperation` and `BatchApplyFormattingInput`
- Shape names with stray whitespace (e.g. `'Title 1 '`) are now normalized before lookup, consistent with all other tool input models

## Background

Reported via Codex review on PR #8. The individual tool models (`SetFillInput`, `FormatTextInput`, etc.) all use `str_strip_whitespace=True`, but `BatchApplyFormattingInput` did not. This caused inconsistent behavior where the same shape name succeeded with individual tools but failed silently in batch operations.

## Test plan
- [ ] Call `ppt_batch_apply_formatting` with a shape name that has trailing spaces (e.g. `"Title 1 "`) — should now resolve correctly instead of returning "not found"

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)