### PR TITLE
fix: set font.NameFarEast alongside font.Name for Japanese text

### DIFF
--- a/src/ppt_com/placeholders.py
+++ b/src/ppt_com/placeholders.py
@@ -253,6 +253,7 @@ def _get_placeholder_impl(slide_index, placeholder_index, placeholder_type) -> d
         info["paragraph_count"] = tr.Paragraphs().Count
         if tf.HasText:
             info["font_name"] = tr.Font.Name
+            info["font_name_far_east"] = tr.Font.NameFarEast
             try:
                 info["font_size"] = tr.Font.Size
             except Exception:

--- a/src/ppt_com/tables.py
+++ b/src/ppt_com/tables.py
@@ -246,6 +246,7 @@ def _set_table_cell_impl(
 
     if font_name is not None:
         font.Name = font_name
+        font.NameFarEast = font_name
     if font_size is not None:
         font.Size = font_size
     if bold is not None:

--- a/src/ppt_com/text.py
+++ b/src/ppt_com/text.py
@@ -312,6 +312,7 @@ def _get_text_impl(slide_index: int, shape_name_or_index) -> dict:
             "start": run.Start,
             "length": run.Length,
             "font_name": font.Name,
+            "font_name_far_east": font.NameFarEast,
             "font_size": font.Size,
             "bold": font.Bold == msoTrue,
             "italic": font.Italic == msoTrue,
@@ -328,6 +329,7 @@ def _apply_font_props(font, font_name, font_size, bold, italic, underline, color
     """Apply font properties to a Font COM object."""
     if font_name is not None:
         font.Name = font_name
+        font.NameFarEast = font_name
     if font_size is not None:
         font.Size = font_size
     if bold is not None:


### PR DESCRIPTION
## Summary

- `font.Name` in PowerPoint COM controls only **Latin/ASCII** characters (A–Z, 0–9)
- **Japanese** (and other CJK) characters are controlled by `font.NameFarEast`
- All font-setting paths were only assigning `font.Name`, leaving Japanese text unchanged
- Read operations (`ppt_get_text`, `ppt_get_placeholder`) only returned `font.Name`, so they falsely reported success even though Japanese text wasn't actually re-fonted

## Changes

| File | Change |
|---|---|
| `src/ppt_com/text.py` `_apply_font_props()` | `+ font.NameFarEast = font_name` — fixes `ppt_format_text`, `ppt_format_text_range`, and `ppt_batch_apply_formatting` (which delegates here) |
| `src/ppt_com/tables.py` `_set_table_cell_impl()` | `+ font.NameFarEast = font_name` |
| `src/ppt_com/text.py` `_get_text_impl()` | `+ "font_name_far_east": font.NameFarEast` per run — makes the actual CJK font visible |
| `src/ppt_com/placeholders.py` `_get_placeholder_impl()` | `+ "font_name_far_east": tr.Font.NameFarEast` |

`ppt_set_default_fonts` in `advanced_ops.py` was already correct (separate `latin` / `east_asian` parameters).

## Test plan

- [ ] `ppt_format_text` with `font_name="游ゴシック"` → Japanese characters visually change to 游ゴシック
- [ ] `ppt_get_text` returns both `font_name` (Latin) and `font_name_far_east` (CJK) per run
- [ ] `ppt_format_text_range` with partial Japanese text → only targeted characters change
- [ ] `ppt_set_table_cell` with `font_name` → table cell Japanese text changes
- [ ] `ppt_get_placeholder` returns `font_name_far_east` field

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)