### PR TITLE
旧リポジトリ名参照を `ppt-mcp` に統一

### DIFF
--- a/src/ppt_com/__init__.py
+++ b/src/ppt_com/__init__.py
@@ -1,1 +1,1 @@
-"""PowerPoint COM automation modules for ppt-com-mcp."""
+"""PowerPoint COM automation modules for ppt-mcp."""

--- a/src/server.py
+++ b/src/server.py
@@ -1,4 +1,4 @@
-"""ppt-com-mcp: The world's best PowerPoint MCP server.
+"""ppt-mcp: The world's best PowerPoint MCP server.
 
 Real-time PowerPoint control via COM automation.
 """

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,4 +1,4 @@
-"""Utility modules for ppt-com-mcp."""
+"""Utility modules for ppt-mcp."""
 
 from .units import (
     inches_to_points,

--- a/uv.lock
+++ b/uv.lock
@@ -362,7 +362,7 @@ wheels = [
 ]
 
 [[package]]
-name = "ppt-com-mcp"
+name = "ppt-mcp"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [


### PR DESCRIPTION
### Motivation
- ユーザー名とリポジトリ名の変更に伴い、コードとロックファイル内に残っていた旧名参照を解消して一貫性を持たせるためです。
- ドキュメント文字列やメタデータに古いパッケージ名が残ると利用者やパッケージング時に混乱を招くため修正しました。

### Description
- モジュールドキュメント文字列を `ppt-com-mcp` から `ppt-mcp` に更新しました（変更ファイル: `src/server.py`, `src/utils/__init__.py`, `src/ppt_com/__init__.py`）。
- 開発環境ロックファイル `uv.lock` 内のローカルパッケージ名を `ppt-com-mcp` から `ppt-mcp` に書き換えました（`[[package]] name = "ppt-mcp"`）。
- 名前変更はコードの実行ロジックには影響しない表記修正のみです。

### Testing
- `python -m compileall src` を実行してソースのコンパイルに成功しました。
- `uv run pytest` を実行しましたが、環境のネットワーク制約により依存パッケージの取得（`https://pypi.org/simple/pydantic/`）で失敗しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a9e9a5240832a9add9522e8dcfbac)