### PR TITLE
feat: add font_color support for SmartArt nodes

### DIFF
--- a/src/ppt_com/smartart.py
+++ b/src/ppt_com/smartart.py
@@ -531,7 +531,7 @@ def register_tools(mcp):
         - color_index: apply a color scheme (use list_type='colors' to find indices)
         - style_index: apply a quick style template (use list_type='styles')
           NOTE: style is applied before color — set both to get both effects.
-        - font_name, font_size, bold: apply to all nodes at once.
+        - font_name, font_size, bold, font_color: apply to all nodes at once.
 
         All positions and sizes are in points (72 points = 1 inch).
         """


### PR DESCRIPTION
## Summary

- Add `font_color: Optional[str]` (`#RRGGBB`) to `AddSmartArtInput` and `ModifySmartArtInput`
- Applied via `TextFrame2.TextRange.Font.Fill.ForeColor.RGB` in `_apply_node_format()`
- Works with `format_node`, `format_all_nodes` actions and `ppt_add_smartart` (all-nodes font block)

## Test plan

- [ ] `ppt_modify_smartart` with `action="format_all_nodes", font_color="#FF0000"` → all node text turns red
- [ ] `ppt_modify_smartart` with `action="format_node", node_index=1, font_color="#FFFFFF"` → node 1 text turns white
- [ ] `ppt_add_smartart` with `font_color="#FFFF00"` → SmartArt created with yellow text

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)