### PR TITLE
fix: warn when visible is set on diagonal borders

### DIFF
--- a/src/ppt_com/tables.py
+++ b/src/ppt_com/tables.py
@@ -47,6 +47,8 @@ BORDER_SIDE_MAP: dict[str, int] = {
     "diagonal_up": ppBorderDiagonalUp,
 }
 
+_DIAGONAL_SIDES: set[int] = {ppBorderDiagonalDown, ppBorderDiagonalUp}
+
 DASH_STYLE_MAP: dict[str, int] = {
     "solid": msoLineSolid,
     "round_dot": msoLineRoundDot,
@@ -695,7 +697,6 @@ def _set_table_borders_impl(
             )
         dash_style_int = DASH_STYLE_MAP[key]
 
-    _DIAGONAL_SIDES = {ppBorderDiagonalDown, ppBorderDiagonalUp}
     diagonal_visible_skipped = False
 
     cells_updated = 0


### PR DESCRIPTION
## Summary

- `ppt_set_table_borders` で `visible` を対角線ボーダー（`diagonal_down`/`diagonal_up`）に設定しようとしても PowerPoint COM の制限で無効になっていたため、`visible` の適用をスキップしてレスポンスに `warnings` フィールドを追加するよう変更
- `sides` フィールドの description に制限事項を明記

## Changes

- `_set_table_borders_impl`: 対角線ボーダーへの `Visible` 設定をスキップ。代わりにレスポンスに `"warnings"` フィールドを含める
- `SetTableBordersInput.sides`: description に PowerPoint COM 制限の注記を追加

## Response example (after fix)

```json
{
  "success": true,
  "cells_updated": 4,
  "rows": "1-4",
  "cols": "1-3",
  "warnings": [
    "visible has no effect on diagonal_down/diagonal_up borders (PowerPoint COM limitation). To hide diagonal borders, set color to match the cell background instead."
  ]
}
```

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)