### PR TITLE
docs: strengthen font size guidance in MCP instruction

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -81,11 +81,12 @@ Before placing any shapes, take a moment to plan:
 
 **Consistency across slides:** use the same heading size, card style, and spacing throughout. `ppt_set_default_shape_style` and `ppt_batch_apply_formatting` are your tools for this.
 
-**Font sizes** — use these ranges as a guide:
+**Font sizes** — minimum sizes for projected readability:
 - Slide title: 40–48 pt
 - Section heading / subheading: 24–32 pt
 - Body text: 20–28 pt
 - Caption / annotation: 16–20 pt
+- **Never go below 16 pt.** Smaller text is unreadable when projected.
 """,
 )
 


### PR DESCRIPTION
## Summary
- Change font size guidance from soft "as a guide" to explicit "minimum sizes for projected readability"
- Add hard floor rule: **Never go below 16 pt**

## Context
During a presentation creation session, 12–15 pt text was used despite existing guidance, because the wording was too soft and positioned at the bottom of the instruction block.

Closes #65

## Test plan
- [x] `uv run pytest` passes (160 tests)
- [ ] Verify the instruction text appears correctly in MCP client

🤖 Generated with [Claude Code](https://claude.com/claude-code)