### PR TITLE
feat: add inline text formatting params to ppt_add_shape

### DIFF
--- a/src/ppt_com/shapes.py
+++ b/src/ppt_com/shapes.py
@@ -349,8 +349,11 @@ def _add_shape_impl(
         if align is not None:
             _ALIGN = {"left": 1, "center": 2, "right": 3, "justify": 4}
             align_val = _ALIGN.get(align.lower())
-            if align_val is not None:
-                shape.TextFrame.TextRange.ParagraphFormat.Alignment = align_val
+            if align_val is None:
+                raise ValueError(
+                    f"Invalid align '{align}'. Must be one of: {sorted(_ALIGN)}"
+                )
+            shape.TextFrame.TextRange.ParagraphFormat.Alignment = align_val
 
     # Inline fill — avoids a follow-up ppt_set_fill call
     _VALID_FILL_TYPES = {"solid", "none", "gradient"}


### PR DESCRIPTION
## Summary
- Add `font_name`, `font_size`, `bold`, `italic`, `font_color`, and `align` parameters to `ppt_add_shape`
- Matches the existing inline styling API of `ppt_add_textbox`, eliminating the need for a separate `ppt_format_text` call when adding styled text to shapes

## Changes
- `AddShapeInput`: 6 new Optional fields added after `text`
- `_add_shape_impl`: font/alignment applied after `TextFrame.TextRange.Text` is set, same pattern as `_add_textbox_impl`
- Tool docstring updated to document the new parameters

Closes #61

## Test plan
- [x] `uv run pytest` passes (160 tests)
- [ ] Manual test: create a shape with `text="Hello"`, `font_name="Segoe UI"`, `font_size=24`, `bold=true`, `font_color="#FF0000"`, `align="center"` — verify text appears styled

🤖 Generated with [Claude Code](https://claude.com/claude-code)