### PR TITLE
feat: add corner_radius param to ppt_add_shape for rounded rectangles

### DIFF
--- a/src/ppt_com/shapes.py
+++ b/src/ppt_com/shapes.py
@@ -144,6 +144,8 @@ class AddShapeInput(BaseModel):
     )
     corner_radius: Optional[float] = Field(
         default=None,
+        ge=0.0,
+        le=1.0,
         description="Corner radius for rounded_rectangle shapes. "
         "Value range: 0.0 (square corners) to 1.0 (maximum rounding). "
         "Ignored for other shape types.",


### PR DESCRIPTION
## Summary
- Add `corner_radius` parameter (0.0–1.0) to `ppt_add_shape` to control corner rounding of `rounded_rectangle` shapes
- Uses `Shape.Adjustments(1)` COM property; silently ignored for other shape types

## Changes
- `AddShapeInput`: new `corner_radius: Optional[float]` field
- `_add_shape_impl`: applies `shape.Adjustments(1, corner_radius)` after shape creation when shape type is `msoShapeRoundedRectangle` (5)

Closes #63

## Test plan
- [x] `uv run pytest` passes (160 tests)
- [ ] Manual test: `ppt_add_shape(shape_type="rounded_rectangle", corner_radius=0.1)` — verify subtle rounding
- [ ] Manual test: `ppt_add_shape(shape_type="rounded_rectangle", corner_radius=0.9)` — verify near-maximum rounding
- [ ] Manual test: `ppt_add_shape(shape_type="rectangle", corner_radius=0.5)` — verify silently ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)