### PR TITLE
feat: batch operations — count for ppt_add_slide, slide_indices for ppt_set_slide_background

### DIFF
--- a/src/ppt_com/layout.py
+++ b/src/ppt_com/layout.py
@@ -138,8 +138,14 @@ class SetSlideBackgroundInput(BaseModel):
 
     @model_validator(mode="after")
     def check_slide_target(self):
-        if self.slide_index is None and self.slide_indices is None:
+        if self.slide_index is None and not self.slide_indices:
             raise ValueError("Either slide_index or slide_indices must be provided")
+        if self.slide_indices:
+            for idx in self.slide_indices:
+                if idx < 1:
+                    raise ValueError(
+                        f"slide_indices must contain positive integers, got {idx}"
+                    )
         return self
 
 

--- a/src/ppt_com/slides.py
+++ b/src/ppt_com/slides.py
@@ -340,7 +340,7 @@ def _add_slide_impl(
         "success": True,
         "slides_created": len(created),
         "slides": created,
-        "layout": layout_val if not use_custom else created[0]["slide_index"],
+        "layout": custom_layout.Name if use_custom else layout_val,
     }
     # Backward compatibility: when count=1, include flat fields
     if count == 1:


### PR DESCRIPTION
## Summary
- `ppt_add_slide`: new `count` parameter to add multiple slides in one call (default: 1)
- `ppt_set_slide_background`: new `slide_indices` parameter to apply the same background to multiple slides at once

Both changes reduce the number of tool calls needed for common presentation setup patterns.

## Changes
- `slides.py`: `AddSlideInput` + `_add_slide_impl` — loop over `count`, layout resolved once outside loop, backward-compatible response
- `layout.py`: `SetSlideBackgroundInput` + `_set_slide_background_impl` — `slide_index` becomes optional, `slide_indices` added with `model_validator` ensuring at least one is provided, background logic looped over target list

Closes #64

## Test plan
- [x] `uv run pytest` passes (160 tests)
- [ ] Manual test: `ppt_add_slide(layout_name="blank", count=5)` — verify 5 slides created
- [ ] Manual test: `ppt_set_slide_background(slide_indices=[1,2,3,4,5], fill_type="solid", color="#0d1117")` — verify all 5 get dark bg
- [ ] Manual test: `ppt_set_slide_background(slide_index=1, ...)` — verify backward compat

🤖 Generated with [Claude Code](https://claude.com/claude-code)