### PR TITLE
feat: add corner_radius param to ppt_add_shape for rounded rectangles

### DIFF
--- a/src/ppt_com/shapes.py
+++ b/src/ppt_com/shapes.py
@@ -399,14 +399,14 @@ def _add_shape_impl(
     if line_weight is not None:
         shape.Line.Weight = line_weight
 
-    # Corner radius for rounded rectangles (msoShapeRoundedRectangle = 5)
+    # Corner radius for rounded rectangles
     if corner_radius is not None:
         try:
-            if shape.AutoShapeType == 5:
-                adj = shape.Adjustments
-                adj(1, corner_radius)
+            if shape.AutoShapeType == SHAPE_NAME_MAP["rounded_rectangle"]:
+                # Map user-facing 0.0–1.0 to COM's 0.0–0.5 range
+                shape.Adjustments[1] = corner_radius * 0.5
         except Exception:
-            pass  # silently ignore if Adjustments not accessible
+            logger.warning("Failed to set corner_radius on shape '%s'", shape.Name)
 
     return {
         "success": True,

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -583,3 +583,61 @@ class TestSetDefaultShapeStyleInput:
         inp = SetDefaultShapeStyleInput()
         assert inp.fill_type is None
         assert inp.slide_index is None
+
+
+# ============================================================================
+# shapes.py — AddShapeInput corner_radius validation
+# ============================================================================
+from ppt_com.shapes import AddShapeInput
+
+
+class TestAddShapeCornerRadius:
+    """Tests for AddShapeInput.corner_radius Pydantic field validation."""
+
+    def test_corner_radius_valid_zero(self):
+        """corner_radius=0.0 (square corners) is accepted."""
+        inp = AddShapeInput(
+            slide_index=1, shape_type="rounded_rectangle",
+            left=0, top=0, width=100, height=50, corner_radius=0.0,
+        )
+        assert inp.corner_radius == 0.0
+
+    def test_corner_radius_valid_one(self):
+        """corner_radius=1.0 (maximum rounding) is accepted."""
+        inp = AddShapeInput(
+            slide_index=1, shape_type="rounded_rectangle",
+            left=0, top=0, width=100, height=50, corner_radius=1.0,
+        )
+        assert inp.corner_radius == 1.0
+
+    def test_corner_radius_valid_mid(self):
+        """corner_radius=0.5 is accepted."""
+        inp = AddShapeInput(
+            slide_index=1, shape_type="rounded_rectangle",
+            left=0, top=0, width=100, height=50, corner_radius=0.5,
+        )
+        assert inp.corner_radius == 0.5
+
+    def test_corner_radius_none_by_default(self):
+        """corner_radius defaults to None."""
+        inp = AddShapeInput(
+            slide_index=1, shape_type="rectangle",
+            left=0, top=0, width=100, height=50,
+        )
+        assert inp.corner_radius is None
+
+    def test_corner_radius_too_high(self):
+        """corner_radius > 1.0 is rejected."""
+        with pytest.raises(ValidationError):
+            AddShapeInput(
+                slide_index=1, shape_type="rounded_rectangle",
+                left=0, top=0, width=100, height=50, corner_radius=1.1,
+            )
+
+    def test_corner_radius_negative(self):
+        """corner_radius < 0.0 is rejected."""
+        with pytest.raises(ValidationError):
+            AddShapeInput(
+                slide_index=1, shape_type="rounded_rectangle",
+                left=0, top=0, width=100, height=50, corner_radius=-0.1,
+            )


### PR DESCRIPTION
## Summary
- Add `corner_radius` parameter (0.0–1.0) to `ppt_add_shape` for controlling rounded rectangle corner rounding
- Includes `ge=0.0, le=1.0` Pydantic validation
- Uses `Shape.Adjustments(1)` COM property; silently ignored for other shape types

Closes #63

Supersedes #69

## Test plan
- [x] `uv run pytest` passes (160 tests)
- [ ] Manual test with PowerPoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)