### PR TITLE
feat: add legend_font_size parameter to ppt_format_chart

### DIFF
--- a/src/ppt_com/charts.py
+++ b/src/ppt_com/charts.py
@@ -118,7 +118,7 @@ class FormatChartInput(BaseModel):
         default=None, description="Built-in chart style index (1-48 typically)"
     )
     legend_font_size: Optional[float] = Field(
-        default=None, description="Legend font size in points"
+        default=None, description="Legend font size in points", gt=0
     )
 
 


### PR DESCRIPTION
## Summary

- `FormatChartInput` に `legend_font_size: Optional[float]` フィールドを追加
- `_format_chart_impl` で `chart.Legend.Font.Size` をセット
- 凡例が非表示の場合はエラーメッセージを返す

## Test plan

- [ ] `ppt_format_chart` に `legend_font_size` を渡して凡例フォントが変わることを確認
- [ ] 凡例なしのチャートに渡してエラーが返ることを確認

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)