### PR TITLE
feat: add crop-to-shape with automatic aspect ratio fitting

### DIFF
--- a/src/ppt_com/advanced_ops.py
+++ b/src/ppt_com/advanced_ops.py
@@ -674,8 +674,8 @@ def _crop_picture_impl(slide_index, shape_name_or_index, crop_left, crop_right,
     if crop_shape is not None:
         if isinstance(crop_shape, str):
             key = crop_shape.strip().lower()
-            if key.lstrip("-").isdigit():
-                # Accept numeric strings like "9" the same as the integer 9
+            if key.isdigit():
+                # Accept non-negative numeric strings like "9" as integer 9
                 auto_shape_int = int(key)
             elif key not in SHAPE_NAME_MAP:
                 raise ValueError(
@@ -768,10 +768,20 @@ def _crop_picture_impl(slide_index, shape_name_or_index, crop_left, crop_right,
     # Apply corner radius for rounded_rectangle crop shapes.
     if corner_radius_pt is not None:
         # msoShapeRoundedRectangle = 5
-        if shape.AutoShapeType == 5:
+        try:
+            current_type = shape.AutoShapeType
+        except Exception:
+            current_type = None
+        if current_type == 5:
             short_side = min(shape.Width, shape.Height)
             adj_value = min(0.5, corner_radius_pt / short_side) if short_side > 0 else 0
             shape.Adjustments[1] = adj_value
+
+    # Read AutoShapeType safely — may fail on msoLinkedPicture (type 11).
+    try:
+        auto_shape_val = shape.AutoShapeType
+    except Exception:
+        auto_shape_val = None
 
     return {
         "success": True,
@@ -782,7 +792,7 @@ def _crop_picture_impl(slide_index, shape_name_or_index, crop_left, crop_right,
         "crop_right": round(pic_fmt.CropRight, 2),
         "crop_top": round(pic_fmt.CropTop, 2),
         "crop_bottom": round(pic_fmt.CropBottom, 2),
-        "crop_shape": shape.AutoShapeType,
+        "crop_shape": auto_shape_val,
     }
 
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -3,7 +3,7 @@
 Covers all model_validator decorated methods in:
 - freeform.py: NodeSpec, BuildFreeformInput, InsertNodeInput
 - tables.py: MergeTableCellsInput, SetTableBordersInput
-- advanced_ops.py: SetDefaultShapeStyleInput
+- advanced_ops.py: SetDefaultShapeStyleInput, CropPictureInput
 - shapes.py: AddShapeInput
 - layout.py: SetSlideBackgroundInput
 - text.py: GetAllTextInput
@@ -27,7 +27,7 @@ from ppt_com.tables import (
     MergeTableCellsInput,
     SetTableBordersInput,
 )
-from ppt_com.advanced_ops import SetDefaultShapeStyleInput
+from ppt_com.advanced_ops import SetDefaultShapeStyleInput, CropPictureInput
 from ppt_com.shapes import AddShapeInput
 from ppt_com.layout import SetSlideBackgroundInput
 from ppt_com.text import GetAllTextInput
@@ -855,3 +855,64 @@ class TestFontSizeWarning:
         result = font_size_warning(8)
         assert result is not None
         assert "8pt" in result
+
+
+# ============================================================================
+# advanced_ops.py — CropPictureInput
+# ============================================================================
+class TestCropPictureInput:
+    """Tests for CropPictureInput validators."""
+
+    def test_crop_fit_alone_valid(self):
+        m = CropPictureInput(slide_index=1, shape_name_or_index="pic", crop_fit="square")
+        assert m.crop_fit == "square"
+        assert m.crop_anchor == 0.5  # default
+
+    def test_crop_fit_with_shape_and_anchor(self):
+        m = CropPictureInput(
+            slide_index=1, shape_name_or_index="pic",
+            crop_fit="1:1", crop_shape="oval", crop_anchor=0.3,
+        )
+        assert m.crop_fit == "1:1"
+        assert m.crop_anchor == 0.3
+
+    def test_crop_fit_with_crop_left_raises(self):
+        with pytest.raises(ValidationError, match="crop_fit cannot be combined"):
+            CropPictureInput(
+                slide_index=1, shape_name_or_index="pic",
+                crop_fit="square", crop_left=10,
+            )
+
+    def test_crop_fit_with_crop_bottom_raises(self):
+        with pytest.raises(ValidationError, match="crop_fit cannot be combined"):
+            CropPictureInput(
+                slide_index=1, shape_name_or_index="pic",
+                crop_fit="square", crop_bottom=5,
+            )
+
+    def test_manual_crop_without_fit_valid(self):
+        m = CropPictureInput(
+            slide_index=1, shape_name_or_index="pic",
+            crop_left=50, crop_right=50, crop_shape="oval",
+        )
+        assert m.crop_left == 50
+        assert m.crop_fit is None
+
+    def test_crop_anchor_bounds(self):
+        with pytest.raises(ValidationError):
+            CropPictureInput(
+                slide_index=1, shape_name_or_index="pic",
+                crop_fit="square", crop_anchor=1.5,
+            )
+        with pytest.raises(ValidationError):
+            CropPictureInput(
+                slide_index=1, shape_name_or_index="pic",
+                crop_fit="square", crop_anchor=-0.1,
+            )
+
+    def test_corner_radius_pt_valid(self):
+        m = CropPictureInput(
+            slide_index=1, shape_name_or_index="pic",
+            crop_shape="rounded_rectangle", corner_radius_pt=10,
+        )
+        assert m.corner_radius_pt == 10


### PR DESCRIPTION
## Summary

Adds crop-to-shape support to `ppt_crop_picture`, including automatic aspect ratio fitting for perfect circle/shape crops from non-square images.

### New parameters

- **`crop_shape`**: Clip picture to a geometric shape (oval, rounded_rectangle, triangle, etc.) via `shape.AutoShapeType`. Accepts friendly names or MsoAutoShapeType integers.
- **`crop_fit='square'`**: Auto-adjusts crop frame to 1:1 aspect ratio before applying crop_shape. Uses `ScaleWidth/ScaleHeight(1.0, msoTrue)` to obtain original image dimensions and calculates CropLeft/CropRight in original-image coordinates. Combined with `crop_shape='oval'`, this produces a perfect circle from any aspect ratio.
- **`crop_anchor`** (0.0–1.0): Controls which part of the image is kept when `crop_fit` is applied. 0.0 = left/top edge, 0.5 = center (default), 1.0 = right/bottom edge.
- **`corner_radius_pt`**: Sets corner radius in points for `rounded_rectangle` crop shapes via `Adjustments[1]`.

### Implementation details

- 2-stage approach for non-square images: (1) calculate crop values from original dimensions, (2) resize shape to target aspect ratio
- Validates `crop_shape` before any mutations to prevent partial updates
- `crop_fit` and manual crop values (`crop_left/right/top/bottom`) are mutually exclusive (Pydantic model_validator)
- Numeric string coercion for `crop_shape` (e.g., `"9"` → `int(9)`)
- COM error wrapping with clear message for invalid AutoShapeType values
- Response includes `width`/`height` for shape dimension visibility

Closes #93

## Test plan

- [x] `crop_shape='oval'` on square image → circle
- [x] `crop_fit='square'` + `crop_shape='oval'` on 16:9 image → perfect circle (no distortion)
- [x] `crop_anchor=0.0` → left-edge crop (shows left portion)
- [x] `crop_anchor=1.0` → right-edge crop (shows right portion)
- [x] `crop_shape='rounded_rectangle'` + `crop_fit='square'` → square rounded rect
- [x] `corner_radius_pt` adjustment for rounded rectangles
- [x] Reset via `crop_left/right/top/bottom=0` + `crop_shape='rectangle'`
- [x] Validation: `crop_fit` + `crop_left` raises error
- [x] 196 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)