### PR TITLE
feat: interactive sequence remove/update support

### DIFF
--- a/src/ppt_com/animation.py
+++ b/src/ppt_com/animation.py
@@ -855,11 +855,11 @@ def _clear_animations_impl(slide_index, clear_transitions):
 
 
 def _update_animation_impl(
-    slide_index, animation_index, effect, trigger, duration, delay, move_to, exit_flag,
+    slide_index, animation_index, sequence_index,
+    effect, trigger, duration, delay, move_to, exit_flag,
     direction, repeat_count, auto_reverse, rewind, smooth_start, smooth_end,
     after_effect, dim_color,
     build_level, text_unit_effect, animate_in_reverse, animate_background,
-    sequence_index,
 ):
     app = ppt._get_app_impl()
     goto_slide(app, slide_index)
@@ -1125,7 +1125,7 @@ def update_animation(params: UpdateAnimationInput) -> str:
     try:
         result = ppt.execute(
             _update_animation_impl,
-            params.slide_index, params.animation_index,
+            params.slide_index, params.animation_index, params.sequence_index,
             params.effect, params.trigger, params.duration,
             params.delay, params.move_to, params.exit,
             params.direction, params.repeat_count, params.auto_reverse,
@@ -1133,7 +1133,6 @@ def update_animation(params: UpdateAnimationInput) -> str:
             params.after_effect, params.dim_color,
             params.build_level, params.text_unit_effect,
             params.animate_in_reverse, params.animate_background,
-            params.sequence_index,
         )
         return json.dumps(result)
     except Exception as e:

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1779,6 +1779,11 @@ class TestRemoveAnimationInputSequenceIndex:
                 slide_index=1, animation_index=1, sequence_index=0,
             )
 
+    def test_sequence_index_default_none(self):
+        """Omitting sequence_index defaults to None (main sequence)."""
+        inp = RemoveAnimationInput(slide_index=1, animation_index=1)
+        assert inp.sequence_index is None
+
 
 # ============================================================================
 # animation.py — UpdateAnimationInput (sequence_index)


### PR DESCRIPTION
## Summary
- Add `sequence_index` parameter to `ppt_remove_animation` and `ppt_update_animation` to target effects within interactive sequences
- When `sequence_index` is provided, resolves `InteractiveSequences(sequence_index)` instead of `MainSequence`
- Includes validation (ge=1) and range checking at runtime

Closes #114

## Test plan
- [x] 4 new validation tests (217 total passing)
- [ ] Manual test: add interactive animation, then remove it via `ppt_remove_animation` with `sequence_index`
- [ ] Manual test: update interactive animation timing via `ppt_update_animation` with `sequence_index`

🤖 Generated with [Claude Code](https://claude.com/claude-code)