### PR TITLE
feat: custom filename for single-slide image export

### DIFF
--- a/src/ppt_com/export.py
+++ b/src/ppt_com/export.py
@@ -10,7 +10,7 @@ import tempfile
 from typing import Optional
 
 import pythoncom
-from pydantic import BaseModel, Field, ConfigDict
+from pydantic import BaseModel, Field, ConfigDict, model_validator
 
 from utils.com_wrapper import ppt
 from ppt_com.constants import (
@@ -80,8 +80,14 @@ class ExportImagesInput(BaseModel):
     )
     file_name: Optional[str] = Field(
         default=None,
-        description="Custom filename for single-slide export (e.g. 'cover.png'). If omitted, defaults to 'Slide{N}.{format}'. Only used with slide_index.",
+        description="Custom filename for single-slide export (e.g. 'cover.png'). If omitted, defaults to 'Slide{N}.{format}'. Requires slide_index.",
     )
+
+    @model_validator(mode="after")
+    def file_name_requires_slide_index(self):
+        if self.file_name is not None and self.slide_index is None:
+            raise ValueError("file_name requires slide_index to be set")
+        return self
 
 
 # ---------------------------------------------------------------------------
@@ -227,9 +233,10 @@ def _export_images_impl(
             os.makedirs(abs_dir, exist_ok=True)
 
         if file_name:
-            # Ensure correct extension
-            if not file_name.lower().endswith(f".{fmt_key}"):
-                file_name = f"{file_name}.{fmt_key}"
+            # Ensure correct extension (strip wrong extension to avoid double ext)
+            base, ext = os.path.splitext(file_name)
+            if ext.lower() != f".{fmt_key}":
+                file_name = f"{base}.{fmt_key}"
         else:
             file_name = f"Slide{slide_index}.{fmt_key}"
         abs_file_path = os.path.join(abs_dir, file_name)

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1968,3 +1968,10 @@ class TestExportImagesInputFileName:
             output_dir="C:/tmp", slide_index=1, file_name="cover",
         )
         assert inp.file_name == "cover"
+
+    def test_file_name_without_slide_index_raises(self):
+        """file_name without slide_index raises ValidationError."""
+        with pytest.raises(ValidationError, match="file_name requires slide_index"):
+            ExportImagesInput(
+                output_dir="C:/tmp", file_name="cover.png",
+            )


### PR DESCRIPTION
## Summary
- Add optional `file_name` parameter to `ppt_export_images`
- When provided with `slide_index`, uses custom name instead of `Slide{N}.{format}`
- Auto-appends correct extension if missing
- No new tools — extends existing tool

Closes #122

## Test plan
- [x] 3 new validation tests (230 total passing)
- [ ] Manual test: export single slide with custom filename
- [ ] Manual test: export without file_name (default behavior unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)