### PR TITLE
feat: SmartArt layout English alias support

### DIFF
--- a/src/ppt_com/smartart.py
+++ b/src/ppt_com/smartart.py
@@ -169,13 +169,23 @@ def _resolve_layout(app, layout_name: str):
             matched_ids.add(layout_id)
 
     if matched_ids:
+        found = []
         for j in range(1, layouts.Count + 1):
             try:
                 lid = layouts(j).Id
-            except Exception:
+            except Exception as e:
+                logger.debug("Cannot read SmartArt layout Id at index %d: %s", j, e)
                 continue
             if lid in matched_ids:
-                return layouts(j)
+                found.append(layouts(j))
+        if found:
+            if len(found) > 1:
+                names = [f.Name for f in found]
+                logger.warning(
+                    "Multiple SmartArt layouts matched '%s': %s — returning first",
+                    layout_name, names,
+                )
+            return found[0]
 
     raise ValueError(
         f"SmartArt layout '{layout_name}' not found. "
@@ -183,9 +193,6 @@ def _resolve_layout(app, layout_name: str):
     )
 
 
-def _get_english_name(layout_id: str) -> Optional[str]:
-    """Return the English alias for a layout Id, or None if not mapped."""
-    return SMARTART_ENGLISH_ALIASES.get(layout_id)
 
 
 # ---------------------------------------------------------------------------
@@ -538,7 +545,7 @@ def _modify_smartart_impl(slide_index, shape_name_or_index, action,
         raise ValueError(
             f"Unknown action '{action}'. Supported: "
             "'set_text', 'add_node', 'delete_node', "
-            "'change_color', 'change_style', "
+            "'change_color', 'change_style', 'change_layout', "
             "'format_node', 'format_all_nodes'"
         )
 
@@ -597,10 +604,7 @@ def _list_smartart_options_impl(list_type, category, keyword, include_descriptio
         # For layouts, resolve the English alias name via layout Id
         english_name = None
         if list_type == "layouts":
-            try:
-                english_name = _get_english_name(item.Id)
-            except Exception:
-                pass
+            english_name = SMARTART_ENGLISH_ALIASES.get(item.Id)
 
         # Category filter (layouts only)
         if cat_lower and list_type == "layouts":
@@ -620,8 +624,7 @@ def _list_smartart_options_impl(list_type, category, keyword, include_descriptio
 
         entry = {"index": i, "name": item_name}
         if list_type == "layouts":
-            if english_name:
-                entry["english_name"] = english_name
+            entry["english_name"] = english_name
             try:
                 entry["category"] = item.Category
             except Exception:

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -2154,7 +2154,6 @@ from ppt_com.smartart import (
     SMARTART_ENGLISH_ALIASES,
     _ENGLISH_NAME_TO_ID,
     _resolve_layout,
-    _get_english_name,
 )
 
 
@@ -2189,13 +2188,13 @@ class TestSmartArtEnglishAliases:
         assert _ENGLISH_NAME_TO_ID["basic process"] == "urn:microsoft.com/office/officeart/2005/8/layout/process1"
         assert _ENGLISH_NAME_TO_ID["organization chart"] == "urn:microsoft.com/office/officeart/2005/8/layout/orgChart1"
 
-    def test_get_english_name_known(self):
-        """_get_english_name returns the English name for a known Id."""
-        assert _get_english_name("urn:microsoft.com/office/officeart/2005/8/layout/process1") == "Basic Process"
+    def test_alias_lookup_known(self):
+        """SMARTART_ENGLISH_ALIASES.get returns the English name for a known Id."""
+        assert SMARTART_ENGLISH_ALIASES.get("urn:microsoft.com/office/officeart/2005/8/layout/process1") == "Basic Process"
 
-    def test_get_english_name_unknown(self):
-        """_get_english_name returns None for an unknown Id."""
-        assert _get_english_name("urn:unknown/layout") is None
+    def test_alias_lookup_unknown(self):
+        """SMARTART_ENGLISH_ALIASES.get returns None for an unknown Id."""
+        assert SMARTART_ENGLISH_ALIASES.get("urn:unknown/layout") is None
 
     def test_all_ids_are_urns(self):
         """All layout Ids should start with 'urn:microsoft.com/'."""


### PR DESCRIPTION
## Summary
- Add English alias mapping (~95 layouts) for SmartArt layout names, enabling locale-independent layout lookup (e.g. `layout_name="Basic Process"` works on Japanese Windows)
- Extract shared `_resolve_layout()` helper with two-phase search: locale name first, then English alias fallback via layout URN ID
- `ppt_list_smartart_layouts` now includes `english_name` field and supports English keyword filtering

## Test plan
- [x] 17 new tests added (alias mapping integrity + `_resolve_layout` with mock COM objects)
- [x] All 266 tests pass (`uv run pytest`)
- [x] `uv run python -c "import src.server"` passes
- [ ] Manual test: `ppt_add_smartart` with `layout_name="Basic Process"` on Japanese Windows
- [ ] Manual test: `ppt_list_smartart_layouts` shows `english_name` fields
- [ ] Manual test: `ppt_list_smartart_layouts` with `keyword="process"` matches English aliases

🤖 Generated with [Claude Code](https://claude.com/claude-code)