### PR TITLE
feat: connector site friendly direction names

### DIFF
--- a/src/ppt_com/connectors.py
+++ b/src/ppt_com/connectors.py
@@ -129,6 +129,7 @@ def _resolve_site(shape, site: Union[int, str]) -> int:
             best_dot = dot
             best_index = i
 
+    # If all sites were at the center (best_dot unchanged), fall back to site 1
     return best_index
 
 
@@ -173,11 +174,14 @@ class AddConnectorInput(BaseModel):
             val = getattr(self, field_name)
             if isinstance(val, int) and val < 1:
                 raise ValueError(f"{field_name} must be >= 1 when specified as int")
-            if isinstance(val, str) and val.strip().lower() not in VALID_SITE_NAMES:
-                raise ValueError(
-                    f"Unknown {field_name} name '{val}'. "
-                    f"Valid names: {VALID_SITE_NAMES}"
-                )
+            if isinstance(val, str):
+                normalized = val.strip().lower()
+                if normalized not in VALID_SITE_NAMES:
+                    raise ValueError(
+                        f"Unknown {field_name} name '{val}'. "
+                        f"Valid names: {VALID_SITE_NAMES}"
+                    )
+                setattr(self, field_name, normalized)
         return self
 
 
@@ -260,11 +264,14 @@ class FormatConnectorInput(BaseModel):
                 continue
             if isinstance(val, int) and val < 1:
                 raise ValueError(f"{field_name} must be >= 1 when specified as int")
-            if isinstance(val, str) and val.strip().lower() not in VALID_SITE_NAMES:
-                raise ValueError(
-                    f"Unknown {field_name} name '{val}'. "
-                    f"Valid names: {VALID_SITE_NAMES}"
-                )
+            if isinstance(val, str):
+                normalized = val.strip().lower()
+                if normalized not in VALID_SITE_NAMES:
+                    raise ValueError(
+                        f"Unknown {field_name} name '{val}'. "
+                        f"Valid names: {VALID_SITE_NAMES}"
+                    )
+                setattr(self, field_name, normalized)
         return self
 
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1150,21 +1150,20 @@ class TestAddConnectorInput:
         assert m.end_site == 1
 
     def test_case_insensitive_site_name(self):
-        """Site names with different casing are accepted (stripped/lowered in validator)."""
+        """Site names with different casing are accepted and normalized to lowercase."""
         m = AddConnectorInput(
             slide_index=1, begin_shape="A", end_shape="B",
             begin_site="Top", end_site="RIGHT",
         )
-        # Pydantic stores the original value; validation passes
-        assert m.begin_site == "Top"
-        assert m.end_site == "RIGHT"
+        assert m.begin_site == "top"
+        assert m.end_site == "right"
 
 
 # ============================================================================
 # connectors.py — FormatConnectorInput arrowhead size fields
 # ============================================================================
 class TestFormatConnectorInput:
-    """Tests for FormatConnectorInput arrowhead size parameters."""
+    """Tests for FormatConnectorInput arrowhead size and site name parameters."""
 
     def test_all_defaults_valid(self):
         """Minimal input with only required fields is accepted."""


### PR DESCRIPTION
## Summary
- Accept string direction names ("top", "bottom", "left", "right") for `begin_site`/`end_site` in `ppt_add_connector` and `ppt_format_connector`
- Coordinate-based resolution: inspects shape's ConnectionSites at runtime and picks the site closest to the named direction — works for any shape type, not just rectangles
- Integer site indices still work (backward compatible)
- Case-insensitive matching

## Test plan
- [x] 13 validator tests (string names, all directions, invalid names, case insensitivity, mixed int+string, backward compat)
- [x] All 292 tests pass
- [ ] Manual test with live PowerPoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)