### PR TITLE
fix: lazy-connect to PowerPoint instead of launching at startup

### DIFF
--- a/src/ppt_com/app.py
+++ b/src/ppt_com/app.py
@@ -51,7 +51,9 @@ class SetWindowStateInput(BaseModel):
 # Implementation functions (run on COM thread via ppt.execute)
 # ---------------------------------------------------------------------------
 def _connect_impl(visible: Optional[bool]) -> dict:
-    app = ppt._connect_impl(visible)
+    # ppt_connect is the user's explicit request to start/attach PowerPoint,
+    # so launching a new instance is allowed here.
+    app = ppt._connect_impl(visible, allow_launch=True)
     return {
         "success": True,
         "name": app.Name,

--- a/src/ppt_com/presentation.py
+++ b/src/ppt_com/presentation.py
@@ -317,7 +317,9 @@ def _create_presentation_impl(
     slide_height: Optional[float],
     preset: Optional[str],
 ) -> dict:
-    app = ppt._get_app_impl()
+    # Creating a new presentation legitimately needs PowerPoint, so launch it
+    # if it isn't already running.
+    app = ppt._get_app_impl(allow_launch=True)
 
     if template_path:
         # Create from template using Open + Untitled=msoTrue
@@ -377,7 +379,8 @@ def _open_presentation_impl(
     if not os.path.exists(file_path):
         raise FileNotFoundError(f"File not found: {file_path}")
 
-    app = ppt._get_app_impl()
+    # Opening a file legitimately needs PowerPoint, so launch it if not running.
+    app = ppt._get_app_impl(allow_launch=True)
     pres = app.Presentations.Open(
         FileName=file_path,
         ReadOnly=msoTrue if read_only else msoFalse,

--- a/src/ppt_com/presentation.py
+++ b/src/ppt_com/presentation.py
@@ -386,8 +386,9 @@ def _open_presentation_impl(
     # Opening a file legitimately needs PowerPoint, so launch it if not running.
     app = ppt._get_app_impl(allow_launch=True)
     # The user just asked to open a deck — make sure it's actually visible
-    # to them, even if PowerPoint was running hidden.
-    if not app.Visible:
+    # to them, even if PowerPoint was running hidden. Skip this when the
+    # caller explicitly requested with_window=False (headless automation).
+    if with_window and not app.Visible:
         app.Visible = True
     pres = app.Presentations.Open(
         FileName=file_path,

--- a/src/ppt_com/presentation.py
+++ b/src/ppt_com/presentation.py
@@ -320,6 +320,10 @@ def _create_presentation_impl(
     # Creating a new presentation legitimately needs PowerPoint, so launch it
     # if it isn't already running.
     app = ppt._get_app_impl(allow_launch=True)
+    # The user just asked to create a deck — make sure it's actually visible
+    # to them, even if PowerPoint was running hidden.
+    if not app.Visible:
+        app.Visible = True
 
     if template_path:
         # Create from template using Open + Untitled=msoTrue
@@ -381,6 +385,10 @@ def _open_presentation_impl(
 
     # Opening a file legitimately needs PowerPoint, so launch it if not running.
     app = ppt._get_app_impl(allow_launch=True)
+    # The user just asked to open a deck — make sure it's actually visible
+    # to them, even if PowerPoint was running hidden.
+    if not app.Visible:
+        app.Visible = True
     pres = app.Presentations.Open(
         FileName=file_path,
         ReadOnly=msoTrue if read_only else msoFalse,

--- a/src/server.py
+++ b/src/server.py
@@ -40,10 +40,11 @@ async def app_lifespan(server: FastMCP):
     logger.info("AUTO_DISMISS_DIALOG=%s (set PPT_AUTO_DISMISS_DIALOG=true to enable)", AUTO_DISMISS_DIALOG)
     logger.info("Starting PowerPoint COM worker thread...")
     ppt.start()
+    # Do NOT connect to PowerPoint here. Connecting at startup would launch
+    # PowerPoint.exe the moment the MCP client boots, even when the user never
+    # invokes a ppt_* tool. The COM connection is established lazily on the
+    # first tool call instead (see PowerPointCOMWrapper._get_app_impl).
     try:
-        # Connect to PowerPoint at startup
-        ppt.connect()
-        logger.info("PowerPoint COM connection established")
         yield {}
     finally:
         logger.info("Shutting down PowerPoint COM worker thread...")

--- a/src/utils/com_wrapper.py
+++ b/src/utils/com_wrapper.py
@@ -162,20 +162,30 @@ class PowerPointCOMWrapper:
         self._queue.put((func, args, kwargs, future))
         return future.result(timeout=30.0)
 
-    def connect(self, visible: Optional[bool] = None) -> Any:
+    def connect(self, visible: Optional[bool] = None, allow_launch: bool = True) -> Any:
         """Connect to PowerPoint (runs on COM thread).
 
         Args:
             visible: If True, make PowerPoint visible. If False, headless mode.
                     If None, don't change visibility (keep current state).
+            allow_launch: If True (default for the public API), launch a new
+                    PowerPoint instance when none is running. If False, only
+                    attach to a running instance and raise ConnectionError
+                    otherwise. Internal callers from generic tools pass False
+                    so that read-only operations don't accidentally spawn
+                    PowerPoint.
 
         Returns:
             PowerPoint.Application COM object
         """
-        return self.execute(self._connect_impl, visible)
+        return self.execute(self._connect_impl, visible, allow_launch)
 
-    def _connect_impl(self, visible: Optional[bool] = None) -> Any:
-        """Internal: connect to PowerPoint on the COM thread."""
+    def _connect_impl(self, visible: Optional[bool] = None, allow_launch: bool = True) -> Any:
+        """Internal: connect to PowerPoint on the COM thread.
+
+        When allow_launch is False, this only attaches to an already-running
+        PowerPoint instance; if none is running, ConnectionError is raised.
+        """
         if self._app is not None:
             try:
                 _ = self._app.Name
@@ -192,17 +202,24 @@ class PowerPointCOMWrapper:
                 self._app = None
 
         # Try existing instance first
+        launched_new = False
         try:
             self._app = win32com.client.GetActiveObject("PowerPoint.Application")
-            logger.info("Connected to existing PowerPoint instance")
+            logger.info("Attached to existing PowerPoint instance")
         except pywintypes.com_error as e:
             if e.hresult in _BUSY_HRESULTS:
                 # PowerPoint is running but busy (modal dialog). Re-raise as
                 # pywintypes.com_error so _com_worker's retry loop handles it.
                 raise
+            if not allow_launch:
+                raise ConnectionError(
+                    "PowerPoint is not running. Call ppt_connect, "
+                    "ppt_create_presentation, or ppt_open_presentation first."
+                ) from e
             try:
                 self._app = win32com.client.Dispatch("PowerPoint.Application")
-                logger.info("Created new PowerPoint instance via Dispatch")
+                logger.info("Launched new PowerPoint instance via Dispatch")
+                launched_new = True
             except pywintypes.com_error as e2:
                 if e2.hresult in _BUSY_HRESULTS:
                     raise  # Let _com_worker retry loop handle it
@@ -212,20 +229,30 @@ class PowerPointCOMWrapper:
 
         if visible is not None:
             self._app.Visible = visible
-        elif not self._app.Visible:
-            # Default: make visible if launching new
+        elif launched_new and not self._app.Visible:
+            # Only force visibility when we ourselves started PowerPoint.
+            # Don't yank a user-hidden running instance to the foreground.
             self._app.Visible = True
 
         return self._app
 
-    def get_app(self) -> Any:
-        """Get the Application object, reconnecting if needed."""
-        return self.execute(self._get_app_impl)
+    def get_app(self, allow_launch: bool = False) -> Any:
+        """Get the Application object, reconnecting if needed.
 
-    def _get_app_impl(self) -> Any:
-        """Internal: get app on COM thread."""
+        Defaults to attach-only; pass allow_launch=True only from tools that
+        legitimately need to start PowerPoint (e.g. create/open presentation).
+        """
+        return self.execute(self._get_app_impl, allow_launch)
+
+    def _get_app_impl(self, allow_launch: bool = False) -> Any:
+        """Internal: get app on COM thread.
+
+        By default refuses to launch PowerPoint — the vast majority of tools
+        operate on an already-open presentation and should fail fast if
+        PowerPoint is not running, instead of silently spawning it.
+        """
         if self._app is None:
-            return self._connect_impl()
+            return self._connect_impl(allow_launch=allow_launch)
         try:
             _ = self._app.Name
             return self._app
@@ -234,11 +261,11 @@ class PowerPointCOMWrapper:
                 raise  # PowerPoint busy — let _com_worker retry loop handle it
             logger.warning("COM connection lost, reconnecting...")
             self._app = None
-            return self._connect_impl()
+            return self._connect_impl(allow_launch=allow_launch)
         except AttributeError:
             logger.warning("COM connection lost, reconnecting...")
             self._app = None
-            return self._connect_impl()
+            return self._connect_impl(allow_launch=allow_launch)
 
     def _get_pres_impl(self) -> Any:
         """Internal: get target presentation on COM thread.

--- a/tests/test_lazy_connect.py
+++ b/tests/test_lazy_connect.py
@@ -1,0 +1,93 @@
+"""Tests for lazy-connect behavior (issue #148).
+
+Verifies that the MCP server does not launch PowerPoint.exe at startup, and
+that _connect_impl / _get_app_impl honor the allow_launch flag.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+import pywintypes
+
+_src_dir = str(Path(__file__).resolve().parents[1] / "src")
+if _src_dir not in sys.path:
+    sys.path.insert(0, _src_dir)
+
+from utils.com_wrapper import PowerPointCOMWrapper  # noqa: E402
+
+
+def _make_busy_error():
+    """Construct a pywintypes.com_error mimicking a non-busy COM failure."""
+    err = pywintypes.com_error(-2147221021, "Operation unavailable", None, None)
+    return err
+
+
+def test_get_app_default_attach_only_raises_when_not_running():
+    """_get_app_impl() with default allow_launch=False must NOT spawn PowerPoint."""
+    w = PowerPointCOMWrapper()
+    with patch("utils.com_wrapper.win32com.client.GetActiveObject",
+               side_effect=_make_busy_error()), \
+         patch("utils.com_wrapper.win32com.client.Dispatch") as dispatch_mock:
+        with pytest.raises(ConnectionError) as exc:
+            w._get_app_impl()
+        # Crucial: Dispatch (which spawns PowerPoint.exe) must never be called.
+        dispatch_mock.assert_not_called()
+        assert "PowerPoint is not running" in str(exc.value)
+
+
+def test_get_app_with_allow_launch_calls_dispatch():
+    """allow_launch=True must fall back to Dispatch when no instance running."""
+    w = PowerPointCOMWrapper()
+    fake_app = MagicMock()
+    fake_app.Visible = False
+    with patch("utils.com_wrapper.win32com.client.GetActiveObject",
+               side_effect=_make_busy_error()), \
+         patch("utils.com_wrapper.win32com.client.Dispatch",
+               return_value=fake_app) as dispatch_mock:
+        app = w._get_app_impl(allow_launch=True)
+        dispatch_mock.assert_called_once_with("PowerPoint.Application")
+        assert app is fake_app
+        # We launched it ourselves, so visibility should be forced True.
+        assert fake_app.Visible is True
+
+
+def test_attach_does_not_force_visibility():
+    """Attaching to a hidden running instance must NOT yank it to foreground."""
+    w = PowerPointCOMWrapper()
+    fake_app = MagicMock()
+    fake_app.Visible = False  # user had it hidden
+    with patch("utils.com_wrapper.win32com.client.GetActiveObject",
+               return_value=fake_app), \
+         patch("utils.com_wrapper.win32com.client.Dispatch") as dispatch_mock:
+        app = w._connect_impl()
+        dispatch_mock.assert_not_called()
+        assert app is fake_app
+        # Critical: we attached, so we must leave Visible alone.
+        assert fake_app.Visible is False
+
+
+def test_explicit_visible_true_is_still_honored_on_attach():
+    """When the caller explicitly passes visible=True, respect that on attach too."""
+    w = PowerPointCOMWrapper()
+    fake_app = MagicMock()
+    fake_app.Visible = False
+    with patch("utils.com_wrapper.win32com.client.GetActiveObject",
+               return_value=fake_app):
+        w._connect_impl(visible=True)
+        assert fake_app.Visible is True
+
+
+def test_server_lifespan_does_not_eager_connect():
+    """Sanity check: server.app_lifespan must not call ppt.connect/_connect_impl."""
+    from pathlib import Path
+    server_src = (Path(__file__).resolve().parents[1] / "src" / "server.py").read_text(encoding="utf-8")
+    # Inside app_lifespan, there must be no ppt.connect()/_connect_impl() call.
+    lifespan_start = server_src.index("async def app_lifespan")
+    lifespan_end = server_src.index("mcp = FastMCP(", lifespan_start)
+    lifespan_block = server_src[lifespan_start:lifespan_end]
+    assert "ppt.connect(" not in lifespan_block
+    assert "_connect_impl(" not in lifespan_block

--- a/tests/test_lazy_connect.py
+++ b/tests/test_lazy_connect.py
@@ -135,6 +135,35 @@ def test_open_presentation_forces_visible_when_powerpoint_running_hidden():
     )
 
 
+def test_open_presentation_preserves_hidden_when_with_window_false():
+    """ppt_open_presentation with with_window=False is the headless workflow.
+    The caller explicitly asked not to surface a window, so don't override
+    Visible. (PR #149 review nit.)
+    """
+    import os
+    from ppt_com import presentation
+
+    fake_app = MagicMock()
+    fake_app.Visible = False
+    fake_pres = MagicMock()
+    fake_pres.Name = "X.pptx"
+    fake_pres.FullName = "C:\\X.pptx"
+    fake_pres.Slides.Count = 1
+    fake_pres.ReadOnly = 0
+    fake_app.Presentations.Open.return_value = fake_pres
+    fake_app.Presentations.Count = 1
+    fake_app.Presentations.return_value = fake_pres
+
+    with patch("ppt_com.presentation.ppt._get_app_impl", return_value=fake_app), \
+         patch.object(os.path, "exists", return_value=True):
+        presentation._open_presentation_impl(
+            file_path="C:\\X.pptx", read_only=False, with_window=False
+        )
+    assert fake_app.Visible is False, (
+        "with_window=False is the headless workflow — Visible must not be forced."
+    )
+
+
 def test_create_presentation_forces_visible_when_powerpoint_running_hidden():
     """Same as above for ppt_create_presentation."""
     from ppt_com import presentation

--- a/tests/test_lazy_connect.py
+++ b/tests/test_lazy_connect.py
@@ -20,8 +20,14 @@ if _src_dir not in sys.path:
 from utils.com_wrapper import PowerPointCOMWrapper  # noqa: E402
 
 
-def _make_busy_error():
-    """Construct a pywintypes.com_error mimicking a non-busy COM failure."""
+def _make_not_running_error():
+    """Construct a pywintypes.com_error indicating PowerPoint is not running.
+
+    HRESULT -2147221021 is MK_E_UNAVAILABLE — PowerPoint is not in the Running
+    Object Table. This is deliberately NOT one of the busy/retry HRESULTs in
+    _BUSY_HRESULTS, so the wrapper treats it as a "no instance" signal rather
+    than retrying.
+    """
     err = pywintypes.com_error(-2147221021, "Operation unavailable", None, None)
     return err
 
@@ -30,7 +36,7 @@ def test_get_app_default_attach_only_raises_when_not_running():
     """_get_app_impl() with default allow_launch=False must NOT spawn PowerPoint."""
     w = PowerPointCOMWrapper()
     with patch("utils.com_wrapper.win32com.client.GetActiveObject",
-               side_effect=_make_busy_error()), \
+               side_effect=_make_not_running_error()), \
          patch("utils.com_wrapper.win32com.client.Dispatch") as dispatch_mock:
         with pytest.raises(ConnectionError) as exc:
             w._get_app_impl()
@@ -45,7 +51,7 @@ def test_get_app_with_allow_launch_calls_dispatch():
     fake_app = MagicMock()
     fake_app.Visible = False
     with patch("utils.com_wrapper.win32com.client.GetActiveObject",
-               side_effect=_make_busy_error()), \
+               side_effect=_make_not_running_error()), \
          patch("utils.com_wrapper.win32com.client.Dispatch",
                return_value=fake_app) as dispatch_mock:
         app = w._get_app_impl(allow_launch=True)
@@ -79,6 +85,77 @@ def test_explicit_visible_true_is_still_honored_on_attach():
                return_value=fake_app):
         w._connect_impl(visible=True)
         assert fake_app.Visible is True
+
+
+def test_stale_app_reconnects_with_attach_only_when_powerpoint_stopped():
+    """If the cached _app is stale and PowerPoint actually stopped,
+    _get_app_impl() with default allow_launch=False must surface a clear
+    ConnectionError instead of silently spawning a new PowerPoint.
+    """
+    w = PowerPointCOMWrapper()
+    stale_app = MagicMock()
+    # Accessing .Name on a stale COM object raises a non-busy com_error.
+    type(stale_app).Name = property(lambda self: (_ for _ in ()).throw(_make_not_running_error()))
+    w._app = stale_app
+    with patch("utils.com_wrapper.win32com.client.GetActiveObject",
+               side_effect=_make_not_running_error()), \
+         patch("utils.com_wrapper.win32com.client.Dispatch") as dispatch_mock:
+        with pytest.raises(ConnectionError):
+            w._get_app_impl()
+        dispatch_mock.assert_not_called()
+
+
+def test_open_presentation_forces_visible_when_powerpoint_running_hidden():
+    """ppt_open_presentation must surface PowerPoint to the user, even if
+    a previously running instance was hidden. Otherwise the user invokes
+    the tool but sees nothing happen (issue #149 review feedback).
+    """
+    import os
+    from ppt_com import presentation
+
+    fake_app = MagicMock()
+    fake_app.Visible = False  # running but hidden
+    fake_pres = MagicMock()
+    fake_pres.Name = "X.pptx"
+    fake_pres.FullName = "C:\\X.pptx"
+    fake_pres.Slides.Count = 1
+    fake_pres.ReadOnly = 0
+    fake_app.Presentations.Open.return_value = fake_pres
+    fake_app.Presentations.Count = 1
+    fake_app.Presentations.return_value = fake_pres  # for the index loop
+
+    with patch("ppt_com.presentation.ppt._get_app_impl", return_value=fake_app), \
+         patch.object(os.path, "exists", return_value=True):
+        presentation._open_presentation_impl(
+            file_path="C:\\X.pptx", read_only=False, with_window=True
+        )
+    assert fake_app.Visible is True, (
+        "ppt_open_presentation must make PowerPoint visible — "
+        "otherwise the user invokes the tool but sees nothing."
+    )
+
+
+def test_create_presentation_forces_visible_when_powerpoint_running_hidden():
+    """Same as above for ppt_create_presentation."""
+    from ppt_com import presentation
+
+    fake_app = MagicMock()
+    fake_app.Visible = False
+    fake_pres = MagicMock()
+    fake_pres.Name = "Untitled.pptx"
+    fake_pres.Slides.Count = 0
+    fake_pres.PageSetup.SlideWidth = 960
+    fake_pres.PageSetup.SlideHeight = 540
+    fake_pres.TemplateName = ""
+    fake_app.Presentations.Add.return_value = fake_pres
+    fake_app.Presentations.Count = 1
+    fake_app.Presentations.return_value = fake_pres
+
+    with patch("ppt_com.presentation.ppt._get_app_impl", return_value=fake_app):
+        presentation._create_presentation_impl(
+            template_path=None, slide_width=None, slide_height=None, preset=None
+        )
+    assert fake_app.Visible is True
 
 
 def test_server_lifespan_does_not_eager_connect():


### PR DESCRIPTION
## Summary

Fixes #148. `ppt-mcp` no longer launches `PowerPoint.exe` when the MCP client (e.g. Claude Code) starts — PowerPoint is now connected to lazily on the first `ppt_*` tool call.

## What changed

- **`src/server.py`** — Removed the eager `ppt.connect()` from `app_lifespan`. The COM worker thread still starts at boot (so the queue is ready), but no `GetActiveObject` / `Dispatch` call is made until a tool actually needs PowerPoint.
- **`src/utils/com_wrapper.py`** — Introduced an `allow_launch` flag on `_connect_impl` / `_get_app_impl` (default `False`). When `False`, the wrapper attaches to a running PowerPoint via `GetActiveObject`, but **refuses to fall through to `Dispatch`** and raises a clear `ConnectionError` instead. Visibility is only forced to `True` when we ourselves launched the instance — a user-hidden running PowerPoint is no longer yanked to the foreground on attach.
- **`src/ppt_com/app.py`** — `ppt_connect` is an explicit user request, so it passes `allow_launch=True`.
- **`src/ppt_com/presentation.py`** — `ppt_create_presentation` and `ppt_open_presentation` legitimately need PowerPoint, so they pass `allow_launch=True`.
- **`tests/test_lazy_connect.py`** — New unit tests covering the attach/launch split, the visibility-on-attach behavior, and a static check that `app_lifespan` doesn't call `ppt.connect`.

All other `_get_app_impl()` callers (shapes, slides, text, charts, etc.) keep the default `allow_launch=False`, which is correct: those tools all presuppose an open presentation, so failing fast with a clear error beats silently spawning PowerPoint.

## Test plan

- [x] `uv run pytest` — 456 passed (including 5 new lazy-connect tests).
- [x] Verified the static lifespan code no longer contains `ppt.connect()`.
- [ ] Manual smoke test on a clean machine with PowerPoint closed: start Claude Code with `ppt-mcp` registered, confirm `POWERPNT.EXE` does **not** appear in Task Manager until `ppt_connect` / `ppt_open_presentation` / `ppt_create_presentation` is invoked.
- [ ] Manual smoke test with PowerPoint already running: confirm the wrapper attaches without changing the window's visibility state.

## Behavior matrix

| Scenario | Before | After |
|---|---|---|
| MCP client boots, PowerPoint not running | `POWERPNT.EXE` spawned, blank window pops up | Nothing happens until a tool is called |
| MCP client boots, PowerPoint already hidden | `Visible=True` forced (window yanked to front) | Unchanged (still hidden) |
| `ppt_open_presentation` while PowerPoint not running | Launches PowerPoint, opens file | Launches PowerPoint, opens file (same) |
| `ppt_get_app_info` while PowerPoint not running | Silently spawns PowerPoint | Returns clear `ConnectionError` |

Closes #148

---

@claude please review.