### PR TITLE
Release v1.1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ppt-mcp"
-version = "1.1.1"
+version = "1.1.2"
 description = "Real-time PowerPoint control via COM automation — an MCP server with 154 tools for AI agents"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Release v1.1.2 — Bugfix

### Highlights

- **fix: lazy-connect to PowerPoint instead of launching at startup (#149, closes #148)** — `ppt-mcp` no longer launches `PowerPoint.exe` the moment the MCP client (e.g. Claude Code) boots. The COM connection is now established lazily on the first `ppt_*` tool call.

### Behavior changes

| Scenario | Before | After |
|---|---|---|
| MCP client boots, PowerPoint not running | `POWERPNT.EXE` spawned, blank window pops up | Nothing happens until a tool is called |
| MCP client boots, PowerPoint already hidden | `Visible=True` forced (window yanked to front) | Unchanged (still hidden) |
| `ppt_open_presentation` / `ppt_create_presentation` while PowerPoint hidden | File opens in hidden instance, no feedback | PowerPoint surfaced so the user can see it |
| `ppt_open_presentation` with `with_window=False` | Window forced regardless | Headless workflow preserved |
| Read-only tools (`ppt_get_app_info`, etc.) while PowerPoint not running | Silently spawned PowerPoint | Returns clear `ConnectionError` |

### Internals

- New `allow_launch` flag on `PowerPointCOMWrapper._connect_impl` / `_get_app_impl` — default `False` (attach-only). Only `ppt_connect`, `ppt_create_presentation`, and `ppt_open_presentation` opt in to launch.
- Visibility is only forced on attach when we ourselves started PowerPoint; a hidden running instance is left alone.
- 9 new tests in `tests/test_lazy_connect.py` cover the lazy-connect, attach/launch split, visibility-on-create/open, `with_window=False` headless path, and stale-`_app` reconnection.