### PR TITLE
feat: enhance ppt_find_replace_text with search-only mode and filters

### DIFF
--- a/src/ppt_com/text.py
+++ b/src/ppt_com/text.py
@@ -283,7 +283,12 @@ class SetBulletInput(BaseModel):
 
 class FindReplaceTextInput(BaseModel):
     """Input for find and replace text."""
-    model_config = ConfigDict(str_strip_whitespace=True)
+    # extra='forbid' rejects unknown fields. This matters for the breaking
+    # rename `slide_index` → `slide_indices`: without it, a caller still
+    # passing the old `slide_index=5` would have the field silently dropped
+    # and the search would fall back to ALL slides — disastrous in replace
+    # mode. With forbid, the legacy field raises a clear ValidationError.
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
 
     find_text: str = Field(..., min_length=1, description="Text to find")
     replace_text: Optional[str] = Field(

--- a/src/ppt_com/text.py
+++ b/src/ppt_com/text.py
@@ -306,6 +306,7 @@ class FindReplaceTextInput(BaseModel):
     )
     shape_name: Optional[str] = Field(
         default=None,
+        min_length=1,
         description="Limit search to a shape with this Name. Applied within each targeted slide.",
     )
     context_chars: int = Field(
@@ -1411,9 +1412,15 @@ def _find_replace_text_impl(
                     hits.append(hit)
                     after = match.Start + match.Length - 1
             else:
+                # Track cursor with `after` so the search advances past each
+                # replacement. With `after=0` fixed we would loop forever when
+                # `replace_text` contains `find_text` (e.g. "foo" -> "foobar").
+                # `max(match.Length, 1)` guarantees forward progress even for
+                # deletions where the replacement length is 0.
+                after = 0
                 while True:
                     match = tr.Replace(
-                        find_text, replace_text, 0, match_case_flag, whole_words_flag
+                        find_text, replace_text, after, match_case_flag, whole_words_flag
                     )
                     if match is None:
                         break
@@ -1426,6 +1433,7 @@ def _find_replace_text_impl(
                     if context_chars > 0:
                         hit["context"] = _build_context(tr.Text, match.Start, match.Length, context_chars)
                     hits.append(hit)
+                    after = match.Start + max(match.Length, 1) - 1
 
     return {
         "status": "success",
@@ -2235,9 +2243,17 @@ def register_tools(mcp):
         Output:
         - `match_count` and `matches` (each with `slide_index`, `shape_name`,
           `start`, `length`, and `context` when `context_chars > 0`).
+        - In replace mode, `length` and the bracketed segment in `context`
+          reflect the replacement text (i.e. what is now in the slide), not
+          the original `find_text`.
 
         Targets only shapes where `HasTextFrame` is true. Table cells, grouped
         shapes, speaker notes, and SmartArt are not searched.
+
+        Note: `readOnlyHint` is `False` because the tool can write. In
+        find-only / dry-run mode the tool performs no writes, but the hint is
+        not adjusted dynamically — clients that gate on the hint may prompt
+        unnecessarily for find-only calls.
         """
         return find_replace_text(params)
 

--- a/src/ppt_com/text.py
+++ b/src/ppt_com/text.py
@@ -285,11 +285,47 @@ class FindReplaceTextInput(BaseModel):
     """Input for find and replace text."""
     model_config = ConfigDict(str_strip_whitespace=True)
 
-    find_text: str = Field(..., description="Text to find")
-    replace_text: str = Field(..., description="Replacement text")
-    slide_index: Optional[int] = Field(
-        default=None, description="1-based slide index. Omit to search all slides."
+    find_text: str = Field(..., min_length=1, description="Text to find")
+    replace_text: Optional[str] = Field(
+        default=None,
+        description="Replacement text. Omit (or use dry_run) to run in find-only mode.",
     )
+    dry_run: bool = Field(
+        default=False,
+        description="If true, find matches without writing — even when replace_text is provided.",
+    )
+    match_case: bool = Field(
+        default=False, description="If true, match is case-sensitive (COM MatchCase)."
+    )
+    whole_words: bool = Field(
+        default=False, description="If true, match whole words only (COM WholeWords)."
+    )
+    slide_indices: Optional[List[int]] = Field(
+        default=None,
+        description="1-based slide indices to search. Omit to search all slides.",
+    )
+    shape_name: Optional[str] = Field(
+        default=None,
+        description="Limit search to a shape with this Name. Applied within each targeted slide.",
+    )
+    context_chars: int = Field(
+        default=0,
+        ge=0,
+        le=500,
+        description="Include N characters of context before/after each hit in the result.",
+    )
+
+    @field_validator("slide_indices")
+    @classmethod
+    def _validate_slide_indices(cls, v):
+        if v is None:
+            return v
+        if len(v) == 0:
+            raise ValueError("slide_indices must not be empty if provided")
+        for i in v:
+            if i < 1:
+                raise ValueError(f"slide_indices entries must be >= 1 (got {i})")
+        return v
 
 
 class SetTextframeInput(BaseModel):
@@ -1321,47 +1357,100 @@ def _set_bullet_impl(slide_index, shape_name_or_index, paragraph_index,
     }
 
 
-def _find_replace_text_impl(find_text, replace_text, slide_index) -> dict:
-    app = ppt._get_app_impl()
+def _find_replace_text_impl(
+    find_text,
+    replace_text,
+    dry_run,
+    match_case,
+    whole_words,
+    slide_indices,
+    shape_name,
+    context_chars,
+) -> dict:
     pres = ppt._get_pres_impl()
+    find_only = replace_text is None or dry_run
 
-    replacements = []
+    match_case_flag = msoTrue if match_case else msoFalse
+    whole_words_flag = msoTrue if whole_words else msoFalse
 
-    if slide_index is not None:
-        slides_to_search = [pres.Slides(slide_index)]
+    if slide_indices is not None:
+        max_index = pres.Slides.Count
+        for i in slide_indices:
+            if i > max_index:
+                raise ValueError(
+                    f"slide_indices entry {i} out of range (1-{max_index})"
+                )
+        slides_to_search = [pres.Slides(i) for i in slide_indices]
     else:
         slides_to_search = [pres.Slides(i) for i in range(1, pres.Slides.Count + 1)]
 
+    hits = []
     for slide in slides_to_search:
         for si in range(1, slide.Shapes.Count + 1):
             shape = slide.Shapes(si)
+            if shape_name is not None and shape.Name != shape_name:
+                continue
             if not shape.HasTextFrame:
                 continue
             tr = shape.TextFrame.TextRange
-            while True:
-                result = tr.Replace(
-                    FindWhat=find_text,
-                    ReplaceWhat=replace_text,
-                    After=0,
-                    MatchCase=msoFalse,
-                    WholeWords=msoFalse,
-                )
-                if result is None:
-                    break
-                replacements.append({
-                    "slide_index": slide.SlideIndex,
-                    "shape_name": shape.Name,
-                    "start": result.Start,
-                    "length": result.Length,
-                })
+
+            if find_only:
+                after = 0
+                while True:
+                    match = tr.Find(find_text, after, match_case_flag, whole_words_flag)
+                    if match is None:
+                        break
+                    hit = {
+                        "slide_index": slide.SlideIndex,
+                        "shape_name": shape.Name,
+                        "start": match.Start,
+                        "length": match.Length,
+                    }
+                    if context_chars > 0:
+                        hit["context"] = _build_context(tr.Text, match.Start, match.Length, context_chars)
+                    hits.append(hit)
+                    after = match.Start + match.Length - 1
+            else:
+                while True:
+                    match = tr.Replace(
+                        find_text, replace_text, 0, match_case_flag, whole_words_flag
+                    )
+                    if match is None:
+                        break
+                    hit = {
+                        "slide_index": slide.SlideIndex,
+                        "shape_name": shape.Name,
+                        "start": match.Start,
+                        "length": match.Length,
+                    }
+                    if context_chars > 0:
+                        hit["context"] = _build_context(tr.Text, match.Start, match.Length, context_chars)
+                    hits.append(hit)
 
     return {
         "status": "success",
+        "mode": "find" if find_only else "replace",
         "find_text": find_text,
         "replace_text": replace_text,
-        "replacement_count": len(replacements),
-        "replacements": replacements,
+        "match_count": len(hits),
+        "matches": hits,
     }
+
+
+def _build_context(full_text, start, length, n):
+    """Build a context string around a match.
+
+    PowerPoint TextRange uses 1-based Start; convert to Python 0-based slicing.
+    """
+    s0 = max(0, start - 1 - n)
+    e0 = min(len(full_text), start - 1 + length + n)
+    match_start = start - 1
+    match_end = start - 1 + length
+    return (
+        full_text[s0:match_start]
+        + "[" + full_text[match_start:match_end] + "]"
+        + full_text[match_end:e0]
+    )
 
 
 def _set_textframe_impl(slide_index, shape_name_or_index,
@@ -1522,11 +1611,29 @@ def set_bullet(params: SetBulletInput) -> str:
 
 
 def find_replace_text(params: FindReplaceTextInput) -> str:
-    """Find and replace text across all slides or a specific slide."""
+    """Find (and optionally replace) text across slides.
+
+    Modes:
+    - Omit `replace_text`, or set `dry_run=True`, to run in find-only mode.
+    - Provide `replace_text` to perform replacement.
+
+    Filters:
+    - `slide_indices`: limit to specific slides.
+    - `shape_name`: limit to a single named shape per slide.
+    - `match_case` / `whole_words`: surfaces COM Find/Replace flags.
+    - `context_chars`: include surrounding text in the result for each hit.
+    """
     try:
         result = ppt.execute(
             _find_replace_text_impl,
-            params.find_text, params.replace_text, params.slide_index,
+            params.find_text,
+            params.replace_text,
+            params.dry_run,
+            params.match_case,
+            params.whole_words,
+            params.slide_indices,
+            params.shape_name,
+            params.context_chars,
         )
         return json.dumps(result)
     except Exception as e:
@@ -2103,7 +2210,7 @@ def register_tools(mcp):
     @mcp.tool(
         name="ppt_find_replace_text",
         annotations={
-            "title": "Find and Replace Text",
+            "title": "Find or Replace Text",
             "readOnlyHint": False,
             "destructiveHint": False,
             "idempotentHint": True,
@@ -2111,10 +2218,26 @@ def register_tools(mcp):
         },
     )
     async def tool_ppt_find_replace_text(params: FindReplaceTextInput) -> str:
-        """Find and replace text across all slides or a specific slide.
+        """Find (and optionally replace) text in shapes that have a text frame.
 
-        Searches all text-containing shapes. If slide_index is omitted,
-        searches the entire presentation.
+        Modes:
+        - Find-only: omit `replace_text`, or pass `dry_run=True`.
+        - Replace: pass `replace_text` (and leave `dry_run=False`).
+
+        Targeting:
+        - `slide_indices` (list of 1-based indices) — omit to search every slide.
+        - `shape_name` — limit to a shape with this exact Name on each targeted slide.
+
+        Match options surfaced from COM Find/Replace:
+        - `match_case` — case-sensitive match.
+        - `whole_words` — whole-word match.
+
+        Output:
+        - `match_count` and `matches` (each with `slide_index`, `shape_name`,
+          `start`, `length`, and `context` when `context_chars > 0`).
+
+        Targets only shapes where `HasTextFrame` is true. Table cells, grouped
+        shapes, speaker notes, and SmartArt are not searched.
         """
         return find_replace_text(params)
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -3071,3 +3071,101 @@ class TestBuildContext:
     def test_zero_context_just_brackets(self):
         ctx = _build_context("hello world", start=7, length=5, n=0)
         assert ctx == "[world]"
+
+
+class TestFindReplaceTextShapeNameEmpty:
+    def test_shape_name_empty_rejected(self):
+        with pytest.raises(ValidationError):
+            FindReplaceTextInput(find_text="x", shape_name="")
+
+
+class TestFindReplaceReplaceLoopCursor:
+    """Regression: Replace loop must advance the After cursor (issue #151 review).
+
+    With the previous code that always passed After=0, a call such as
+    find_text='foo' + replace_text='foobar' would re-find 'foo' inside the
+    newly inserted 'foobar' on every iteration and loop forever.
+    """
+
+    def _build_mock_pres(self, replace_returns, text="foobar"):
+        """Build a mock pres.Slides(i).Shapes(j) chain with a single shape."""
+        replace_calls = []
+
+        def fake_replace(find_what, replace_what, after, match_case, whole_words):
+            idx = len(replace_calls)
+            replace_calls.append(after)
+            if idx < len(replace_returns):
+                spec = replace_returns[idx]
+                if spec is None:
+                    return None
+                m = MagicMock()
+                m.Start = spec["Start"]
+                m.Length = spec["Length"]
+                return m
+            return None
+
+        tr = MagicMock()
+        tr.Replace = fake_replace
+        tr.Text = text
+
+        shape = MagicMock()
+        shape.HasTextFrame = True
+        shape.Name = "TB"
+        shape.TextFrame.TextRange = tr
+
+        slide = MagicMock()
+        slide.SlideIndex = 1
+        slide.Shapes.Count = 1
+        slide.Shapes.return_value = shape
+
+        pres = MagicMock()
+        pres.Slides.Count = 1
+        pres.Slides.return_value = slide
+        return pres, replace_calls
+
+    def test_after_cursor_advances_between_iterations(self):
+        from ppt_com import text as text_mod
+
+        pres, replace_calls = self._build_mock_pres(
+            replace_returns=[
+                {"Start": 1, "Length": 6},   # first hit replaced
+                {"Start": 10, "Length": 6},  # second hit replaced
+                None,                         # no more matches
+            ]
+        )
+
+        with patch.object(text_mod.ppt, "_get_pres_impl", return_value=pres):
+            result = text_mod._find_replace_text_impl(
+                find_text="foo", replace_text="foobar",
+                dry_run=False, match_case=False, whole_words=False,
+                slide_indices=None, shape_name=None, context_chars=0,
+            )
+
+        assert result["match_count"] == 2
+        assert len(replace_calls) == 3
+        assert replace_calls[0] == 0, "First call must start from After=0"
+        assert replace_calls[1] == 6, "Second call must advance to past first match"
+        assert replace_calls[2] == 15, "Third call must advance to past second match"
+
+    def test_deletion_makes_forward_progress(self):
+        """When replace_text is empty, match.Length=0 — the cursor must still advance."""
+        from ppt_com import text as text_mod
+
+        pres, replace_calls = self._build_mock_pres(
+            replace_returns=[
+                {"Start": 1, "Length": 0},  # deletion at start
+                None,
+            ]
+        )
+        with patch.object(text_mod.ppt, "_get_pres_impl", return_value=pres):
+            result = text_mod._find_replace_text_impl(
+                find_text="foo", replace_text="",
+                dry_run=False, match_case=False, whole_words=False,
+                slide_indices=None, shape_name=None, context_chars=0,
+            )
+
+        assert result["match_count"] == 1
+        assert replace_calls[0] == 0
+        assert replace_calls[1] >= 1, (
+            "After deletion (Length=0), cursor must still advance past Start"
+        )

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -3044,12 +3044,18 @@ class TestFindReplaceTextInput:
         with pytest.raises(ValidationError):
             FindReplaceTextInput(find_text="x", context_chars=501)
 
-    def test_slide_index_old_field_removed(self):
-        """slide_index (singular) is no longer accepted — must use slide_indices."""
-        # pydantic ignores unknown fields by default unless model_config extra='forbid',
-        # so this asserts that passing the old field has no effect (slide_indices stays None).
-        inp = FindReplaceTextInput(find_text="x", slide_index=5)
-        assert inp.slide_indices is None
+    def test_slide_index_old_field_rejected(self):
+        """The legacy singular `slide_index` must be rejected loudly.
+
+        Silently ignoring it would let a caller intend to limit the search
+        to one slide and instead get a presentation-wide replace.
+        """
+        with pytest.raises(ValidationError, match="slide_index"):
+            FindReplaceTextInput(find_text="x", slide_index=5)
+
+    def test_unknown_field_rejected(self):
+        with pytest.raises(ValidationError):
+            FindReplaceTextInput(find_text="x", foobar=True)
 
 
 class TestBuildContext:

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -38,7 +38,8 @@ from ppt_com.layout import SetSlideBackgroundInput
 from ppt_com.slides import SetSlideNotesInput
 from ppt_com.text import (
     GetAllTextInput, SetBulletInput, SetParagraphFormatInput,
-    CheckTypographyInput, _is_latin, _char_type, _find_best_vbreak,
+    CheckTypographyInput, FindReplaceTextInput,
+    _is_latin, _char_type, _find_best_vbreak, _build_context,
 )
 from ppt_com.themes import (
     SetThemeColorsInput, PRESET_PALETTES,
@@ -2968,3 +2969,105 @@ class TestSetSlideNotesInput:
         assert inp.bold is None
         assert inp.italic is None
         assert inp.color is None
+
+
+# ============================================================================
+# FindReplaceTextInput
+# ============================================================================
+
+class TestFindReplaceTextInput:
+    """Tests for the enhanced ppt_find_replace_text input (issue #151)."""
+
+    def test_defaults(self):
+        inp = FindReplaceTextInput(find_text="hello")
+        assert inp.find_text == "hello"
+        assert inp.replace_text is None
+        assert inp.dry_run is False
+        assert inp.match_case is False
+        assert inp.whole_words is False
+        assert inp.slide_indices is None
+        assert inp.shape_name is None
+        assert inp.context_chars == 0
+
+    def test_find_text_required_and_nonempty(self):
+        with pytest.raises(ValidationError):
+            FindReplaceTextInput()
+        with pytest.raises(ValidationError):
+            FindReplaceTextInput(find_text="")
+
+    def test_replace_text_optional(self):
+        inp = FindReplaceTextInput(find_text="x", replace_text="y")
+        assert inp.replace_text == "y"
+        inp = FindReplaceTextInput(find_text="x", replace_text="")
+        assert inp.replace_text == ""
+
+    def test_dry_run_with_replace_text(self):
+        """dry_run can coexist with replace_text; impl treats it as find-only."""
+        inp = FindReplaceTextInput(find_text="x", replace_text="y", dry_run=True)
+        assert inp.dry_run is True
+        assert inp.replace_text == "y"
+
+    def test_match_flags(self):
+        inp = FindReplaceTextInput(find_text="x", match_case=True, whole_words=True)
+        assert inp.match_case is True
+        assert inp.whole_words is True
+
+    def test_slide_indices_valid(self):
+        inp = FindReplaceTextInput(find_text="x", slide_indices=[1, 3, 5])
+        assert inp.slide_indices == [1, 3, 5]
+
+    def test_slide_indices_empty_rejected(self):
+        with pytest.raises(ValidationError, match="empty"):
+            FindReplaceTextInput(find_text="x", slide_indices=[])
+
+    def test_slide_indices_zero_rejected(self):
+        with pytest.raises(ValidationError, match=">= 1"):
+            FindReplaceTextInput(find_text="x", slide_indices=[1, 0, 2])
+
+    def test_slide_indices_negative_rejected(self):
+        with pytest.raises(ValidationError, match=">= 1"):
+            FindReplaceTextInput(find_text="x", slide_indices=[-1])
+
+    def test_shape_name(self):
+        inp = FindReplaceTextInput(find_text="x", shape_name="Title 1")
+        assert inp.shape_name == "Title 1"
+
+    def test_context_chars_range(self):
+        inp = FindReplaceTextInput(find_text="x", context_chars=20)
+        assert inp.context_chars == 20
+        inp = FindReplaceTextInput(find_text="x", context_chars=500)
+        assert inp.context_chars == 500
+
+    def test_context_chars_out_of_range(self):
+        with pytest.raises(ValidationError):
+            FindReplaceTextInput(find_text="x", context_chars=-1)
+        with pytest.raises(ValidationError):
+            FindReplaceTextInput(find_text="x", context_chars=501)
+
+    def test_slide_index_old_field_removed(self):
+        """slide_index (singular) is no longer accepted — must use slide_indices."""
+        # pydantic ignores unknown fields by default unless model_config extra='forbid',
+        # so this asserts that passing the old field has no effect (slide_indices stays None).
+        inp = FindReplaceTextInput(find_text="x", slide_index=5)
+        assert inp.slide_indices is None
+
+
+class TestBuildContext:
+    """Tests for the _build_context helper used in match results."""
+
+    def test_basic_context(self):
+        # full_text = "abcdEFGhij", match "EFG" at 1-based start=5, length=3
+        ctx = _build_context("abcdEFGhij", start=5, length=3, n=2)
+        assert ctx == "cd[EFG]hi"
+
+    def test_clamps_to_start(self):
+        ctx = _build_context("hello world", start=1, length=5, n=10)
+        assert ctx == "[hello] world"
+
+    def test_clamps_to_end(self):
+        ctx = _build_context("hello world", start=7, length=5, n=10)
+        assert ctx == "hello [world]"
+
+    def test_zero_context_just_brackets(self):
+        ctx = _build_context("hello world", start=7, length=5, n=0)
+        assert ctx == "[world]"

--- a/uv.lock
+++ b/uv.lock
@@ -390,7 +390,7 @@ wheels = [
 
 [[package]]
 name = "ppt-mcp"
-version = "0.8.2"
+version = "1.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },


### PR DESCRIPTION
## Summary
- Extend `ppt_find_replace_text` so it can also be used purely for searching, with finer-grained targeting and richer output.
- Surface the COM `Find` / `Replace` flags `MatchCase` and `WholeWords` that were previously hard-coded off.
- Add slide-list / shape-name filters and an optional `context_chars` to include the surrounding text in each hit.

## Schema changes (FindReplaceTextInput)
| Field | Change |
|------|------|
| `replace_text: str` | → `Optional[str] = None` — omit for find-only mode |
| `dry_run: bool = False` | new — find without writing |
| `match_case: bool = False` | new — surface COM `MatchCase` |
| `whole_words: bool = False` | new — surface COM `WholeWords` |
| `slide_index: int` | → `slide_indices: Optional[List[int]] = None` (breaking) |
| `shape_name: Optional[str] = None` | new — limit to a single shape per slide |
| `context_chars: int = 0` | new — N chars before/after each hit |

## Test plan
- [x] `uv run pytest` — 477 passed (17 new tests for `FindReplaceTextInput` and `_build_context`)
- [x] `bash scripts/count_tools.sh` — total still 154 (no new tool added)
- [x] Manual against a live PowerPoint:
  - find-only with `context_chars=10` — 3 hits returned with surrounding text
  - `match_case=true` — distinguishes `Apple` vs `apple`
  - `whole_words=true` — matches `foo` / `Foo` only as whole words
  - `slide_indices=[2]` — limits scope to slide 2 only
  - `shape_name="TextBox 1"` combined with `slide_indices=[1,3]` — limits to that shape on listed slides
  - `dry_run=true` with `replace_text` — returned `mode: "find"` and the slide text was unchanged after the call
  - actual replace with `match_case=true` — only the lowercase occurrence was replaced

## Notes
- `slide_index` (singular) was removed in favor of `slide_indices` (list). This is a breaking change to the tool schema; acceptable for an LLM-facing MCP tool.
- Out of scope: regex support, expanding the target to tables / groups / speaker notes / SmartArt — tracked as future work.

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)