### PR TITLE
fix: auto-activate newly created / opened presentations

### DIFF
--- a/src/ppt_com/presentation.py
+++ b/src/ppt_com/presentation.py
@@ -54,7 +54,7 @@ SLIDE_SIZE_PRESETS = {
 # ---------------------------------------------------------------------------
 class CreatePresentationInput(BaseModel):
     """Input for creating a new presentation."""
-    model_config = ConfigDict(str_strip_whitespace=True)
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
 
     template_path: Optional[str] = Field(
         default=None,
@@ -88,11 +88,20 @@ class CreatePresentationInput(BaseModel):
             "Ignored if template_path is provided."
         ),
     )
+    activate: bool = Field(
+        default=True,
+        description=(
+            "If true (default), the newly created presentation becomes the "
+            "session target — subsequent tool calls operate on it regardless "
+            "of which window the user clicks into. Set false to keep an "
+            "existing session target."
+        ),
+    )
 
 
 class OpenPresentationInput(BaseModel):
     """Input for opening an existing presentation."""
-    model_config = ConfigDict(str_strip_whitespace=True)
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
 
     file_path: str = Field(
         ...,
@@ -105,6 +114,15 @@ class OpenPresentationInput(BaseModel):
     with_window: bool = Field(
         default=True,
         description="If true, open with a visible window. Set false for background processing.",
+    )
+    activate: bool = Field(
+        default=True,
+        description=(
+            "If true (default), the opened presentation becomes the session "
+            "target — subsequent tool calls operate on it regardless of which "
+            "window the user clicks into. Set false to keep an existing "
+            "session target."
+        ),
     )
 
 
@@ -316,6 +334,7 @@ def _create_presentation_impl(
     slide_width: Optional[float],
     slide_height: Optional[float],
     preset: Optional[str],
+    activate: bool,
 ) -> dict:
     # Creating a new presentation legitimately needs PowerPoint, so launch it
     # if it isn't already running.
@@ -364,6 +383,13 @@ def _create_presentation_impl(
             pres_index = i
             break
 
+    if activate:
+        try:
+            pres.Windows(1).Activate()
+        except Exception as e:
+            logger.warning("Could not activate new presentation window: %s", e)
+        ppt._target_pres_full_name = pres.FullName
+
     return {
         "success": True,
         "presentation_index": pres_index,
@@ -372,6 +398,7 @@ def _create_presentation_impl(
         "slide_width": pres.PageSetup.SlideWidth,
         "slide_height": pres.PageSetup.SlideHeight,
         "template_name": template_name,
+        "activated": activate,
     }
 
 
@@ -379,6 +406,7 @@ def _open_presentation_impl(
     file_path: str,
     read_only: bool,
     with_window: bool,
+    activate: bool,
 ) -> dict:
     if not os.path.exists(file_path):
         raise FileNotFoundError(f"File not found: {file_path}")
@@ -404,6 +432,17 @@ def _open_presentation_impl(
             pres_index = i
             break
 
+    if activate and with_window:
+        try:
+            pres.Windows(1).Activate()
+        except Exception as e:
+            logger.warning("Could not activate opened presentation window: %s", e)
+        ppt._target_pres_full_name = pres.FullName
+    elif activate and not with_window:
+        # Headless open — no window to activate but still set the session
+        # target so subsequent tool calls land on this deck.
+        ppt._target_pres_full_name = pres.FullName
+
     return {
         "success": True,
         "presentation_index": pres_index,
@@ -411,6 +450,7 @@ def _open_presentation_impl(
         "full_name": pres.FullName,
         "slides_count": pres.Slides.Count,
         "read_only": int(pres.ReadOnly) == -1,  # msoTrue=-1; bool() misidentifies msoCTrue(1)
+        "activated": activate,
     }
 
 
@@ -671,6 +711,7 @@ def create_presentation(params: CreatePresentationInput) -> str:
             params.slide_width,
             params.slide_height,
             params.preset,
+            params.activate,
         )
         return json.dumps(result)
     except Exception as e:
@@ -685,6 +726,7 @@ def open_presentation(params: OpenPresentationInput) -> str:
             params.file_path,
             params.read_only,
             params.with_window,
+            params.activate,
         )
         return json.dumps(result)
     except Exception as e:
@@ -794,6 +836,11 @@ def register_tools(mcp):
         For blank presentations, set slide dimensions via a preset ('16:9'
         or '4:3') or explicit width/height in points (72 pt = 1 inch).
         Size parameters are ignored when a template is used.
+
+        By default the newly created presentation becomes the MCP session
+        target, so subsequent tool calls operate on it even if the user
+        clicks into another window. Pass `activate=false` to keep the
+        existing target.
         """
         return create_presentation(params)
 
@@ -813,6 +860,10 @@ def register_tools(mcp):
         Supports .pptx, .pptm, .ppt, .potx, .ppsx and other PowerPoint formats.
         Set read_only=true to prevent accidental edits.
         Set with_window=false for background processing.
+
+        By default the opened presentation becomes the MCP session target,
+        so subsequent tool calls operate on it even if the user clicks into
+        another window. Pass `activate=false` to keep the existing target.
         """
         return open_presentation(params)
 

--- a/tests/test_lazy_connect.py
+++ b/tests/test_lazy_connect.py
@@ -274,6 +274,31 @@ def test_create_presentation_activate_true_sets_target():
         assert presentation.ppt._target_pres_full_name == "C:\\New.pptx"
 
 
+def test_open_presentation_activate_true_sets_target():
+    """Parallel positive-path test for ppt_open_presentation."""
+    import os
+    from ppt_com import presentation
+
+    fake_app = MagicMock()
+    fake_app.Visible = True
+    fake_pres = MagicMock()
+    fake_pres.Name = "Opened.pptx"
+    fake_pres.FullName = "C:\\Opened.pptx"
+    fake_pres.Slides.Count = 1
+    fake_pres.ReadOnly = 0
+    fake_app.Presentations.Open.return_value = fake_pres
+    fake_app.Presentations.Count = 1
+    fake_app.Presentations.return_value = fake_pres
+
+    with patch("ppt_com.presentation.ppt._get_app_impl", return_value=fake_app), \
+         patch.object(os.path, "exists", return_value=True), \
+         patch.object(presentation.ppt, "_target_pres_full_name", None):
+        presentation._open_presentation_impl(
+            file_path="C:\\Opened.pptx", read_only=False, with_window=True, activate=True
+        )
+        assert presentation.ppt._target_pres_full_name == "C:\\Opened.pptx"
+
+
 def test_server_lifespan_does_not_eager_connect():
     """Sanity check: server.app_lifespan must not call ppt.connect/_connect_impl."""
     from pathlib import Path

--- a/tests/test_lazy_connect.py
+++ b/tests/test_lazy_connect.py
@@ -187,6 +187,93 @@ def test_create_presentation_forces_visible_when_powerpoint_running_hidden():
     assert fake_app.Visible is True
 
 
+def test_create_presentation_activate_false_does_not_set_target():
+    """activate=False must not overwrite an existing session target.
+
+    Issue #155 review: the Pydantic tests cover the schema, but the
+    behavioral guarantee that opt-out preserves the target needs its own test.
+    """
+    from ppt_com import presentation
+
+    fake_app = MagicMock()
+    fake_app.Visible = True
+    fake_pres = MagicMock()
+    fake_pres.Name = "New.pptx"
+    fake_pres.FullName = "C:\\New.pptx"
+    fake_pres.Slides.Count = 0
+    fake_pres.PageSetup.SlideWidth = 960
+    fake_pres.PageSetup.SlideHeight = 540
+    fake_pres.TemplateName = ""
+    fake_app.Presentations.Add.return_value = fake_pres
+    fake_app.Presentations.Count = 1
+    fake_app.Presentations.return_value = fake_pres
+
+    sentinel = "C:\\Existing.pptx"
+    with patch("ppt_com.presentation.ppt._get_app_impl", return_value=fake_app), \
+         patch.object(presentation.ppt, "_target_pres_full_name", sentinel):
+        presentation._create_presentation_impl(
+            template_path=None, slide_width=None, slide_height=None,
+            preset=None, activate=False,
+        )
+        assert presentation.ppt._target_pres_full_name == sentinel, (
+            "activate=False must leave the existing session target untouched"
+        )
+
+
+def test_open_presentation_activate_false_does_not_set_target():
+    """Parallel test for ppt_open_presentation."""
+    import os
+    from ppt_com import presentation
+
+    fake_app = MagicMock()
+    fake_app.Visible = True
+    fake_pres = MagicMock()
+    fake_pres.Name = "X.pptx"
+    fake_pres.FullName = "C:\\X.pptx"
+    fake_pres.Slides.Count = 1
+    fake_pres.ReadOnly = 0
+    fake_app.Presentations.Open.return_value = fake_pres
+    fake_app.Presentations.Count = 1
+    fake_app.Presentations.return_value = fake_pres
+
+    sentinel = "C:\\Existing.pptx"
+    with patch("ppt_com.presentation.ppt._get_app_impl", return_value=fake_app), \
+         patch.object(os.path, "exists", return_value=True), \
+         patch.object(presentation.ppt, "_target_pres_full_name", sentinel):
+        presentation._open_presentation_impl(
+            file_path="C:\\X.pptx", read_only=False, with_window=True, activate=False
+        )
+        assert presentation.ppt._target_pres_full_name == sentinel, (
+            "activate=False must leave the existing session target untouched"
+        )
+
+
+def test_create_presentation_activate_true_sets_target():
+    """Confirms activate=True sets _target_pres_full_name to the new deck's FullName."""
+    from ppt_com import presentation
+
+    fake_app = MagicMock()
+    fake_app.Visible = True
+    fake_pres = MagicMock()
+    fake_pres.Name = "New.pptx"
+    fake_pres.FullName = "C:\\New.pptx"
+    fake_pres.Slides.Count = 0
+    fake_pres.PageSetup.SlideWidth = 960
+    fake_pres.PageSetup.SlideHeight = 540
+    fake_pres.TemplateName = ""
+    fake_app.Presentations.Add.return_value = fake_pres
+    fake_app.Presentations.Count = 1
+    fake_app.Presentations.return_value = fake_pres
+
+    with patch("ppt_com.presentation.ppt._get_app_impl", return_value=fake_app), \
+         patch.object(presentation.ppt, "_target_pres_full_name", None):
+        presentation._create_presentation_impl(
+            template_path=None, slide_width=None, slide_height=None,
+            preset=None, activate=True,
+        )
+        assert presentation.ppt._target_pres_full_name == "C:\\New.pptx"
+
+
 def test_server_lifespan_does_not_eager_connect():
     """Sanity check: server.app_lifespan must not call ppt.connect/_connect_impl."""
     from pathlib import Path

--- a/tests/test_lazy_connect.py
+++ b/tests/test_lazy_connect.py
@@ -127,7 +127,7 @@ def test_open_presentation_forces_visible_when_powerpoint_running_hidden():
     with patch("ppt_com.presentation.ppt._get_app_impl", return_value=fake_app), \
          patch.object(os.path, "exists", return_value=True):
         presentation._open_presentation_impl(
-            file_path="C:\\X.pptx", read_only=False, with_window=True
+            file_path="C:\\X.pptx", read_only=False, with_window=True, activate=True
         )
     assert fake_app.Visible is True, (
         "ppt_open_presentation must make PowerPoint visible — "
@@ -157,7 +157,7 @@ def test_open_presentation_preserves_hidden_when_with_window_false():
     with patch("ppt_com.presentation.ppt._get_app_impl", return_value=fake_app), \
          patch.object(os.path, "exists", return_value=True):
         presentation._open_presentation_impl(
-            file_path="C:\\X.pptx", read_only=False, with_window=False
+            file_path="C:\\X.pptx", read_only=False, with_window=False, activate=True
         )
     assert fake_app.Visible is False, (
         "with_window=False is the headless workflow — Visible must not be forced."
@@ -182,7 +182,7 @@ def test_create_presentation_forces_visible_when_powerpoint_running_hidden():
 
     with patch("ppt_com.presentation.ppt._get_app_impl", return_value=fake_app):
         presentation._create_presentation_impl(
-            template_path=None, slide_width=None, slide_height=None, preset=None
+            template_path=None, slide_width=None, slide_height=None, preset=None, activate=True
         )
     assert fake_app.Visible is True
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -35,6 +35,7 @@ from ppt_com.shapes import AddShapeInput, UpdateShapeInput
 from ppt_com.animation import AddAnimationInput, RemoveAnimationInput, UpdateAnimationInput
 from ppt_com.connectors import AddConnectorInput, FormatConnectorInput
 from ppt_com.layout import SetSlideBackgroundInput
+from ppt_com.presentation import CreatePresentationInput, OpenPresentationInput
 from ppt_com.slides import SetSlideNotesInput
 from ppt_com.text import (
     GetAllTextInput, SetBulletInput, SetParagraphFormatInput,
@@ -3175,3 +3176,35 @@ class TestFindReplaceReplaceLoopCursor:
         assert replace_calls[1] >= 1, (
             "After deletion (Length=0), cursor must still advance past Start"
         )
+
+
+# ============================================================================
+# presentation.py — CreatePresentationInput / OpenPresentationInput (issue #155)
+# ============================================================================
+
+class TestCreatePresentationInputActivate:
+    def test_activate_default_true(self):
+        inp = CreatePresentationInput()
+        assert inp.activate is True
+
+    def test_activate_explicit_false(self):
+        inp = CreatePresentationInput(activate=False)
+        assert inp.activate is False
+
+    def test_unknown_field_rejected(self):
+        with pytest.raises(ValidationError):
+            CreatePresentationInput(activte=True)  # typo
+
+
+class TestOpenPresentationInputActivate:
+    def test_activate_default_true(self):
+        inp = OpenPresentationInput(file_path="C:/x.pptx")
+        assert inp.activate is True
+
+    def test_activate_explicit_false(self):
+        inp = OpenPresentationInput(file_path="C:/x.pptx", activate=False)
+        assert inp.activate is False
+
+    def test_unknown_field_rejected(self):
+        with pytest.raises(ValidationError):
+            OpenPresentationInput(file_path="C:/x.pptx", activte=True)  # typo


### PR DESCRIPTION
## Summary
- Add `activate: bool = True` to `CreatePresentationInput` and `OpenPresentationInput`.
- When true (default), the new/opened presentation is set as the MCP session target (`ppt._target_pres_full_name = pres.FullName`), so subsequent tool calls operate on it regardless of which window the user clicks into.
- Set `extra='forbid'` on both input models so future typos like `activte: true` raise a `ValidationError` instead of being silently dropped.

## Why
The current behavior caused a real incident: after calling `ppt_create_presentation(activate=true)` (which Pydantic was silently ignoring), a follow-up `ppt_add_textbox` landed in an unrelated presentation the user had open in another window. The fix matches the safer behavior callers expect from the `activate` flag.

## Test plan
- [x] `uv run pytest` — 487 passed (6 new validator tests + 3 lazy-connect tests updated for the new positional arg).
- [x] Manual against live PowerPoint with 3 unrelated decks open:
  - `ppt_create_presentation()` (default activate=true) → `activated: true` in the response; subsequent `ppt_add_textbox(slide_index=1, ...)` lands on the new deck (shape_index=1).
  - `ppt_create_presentation(activte=true)` (typo) → `ValidationError: Extra inputs are not permitted`.

## Out of scope
- Unsaved presentations whose `FullName` changes when saved later — pre-existing limitation of `_target_pres_full_name` and tracked separately if needed.

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)