### PR TITLE
feat: add color, size, font, numbered style, and text-link toggles to ppt_set_bullet

### DIFF
--- a/src/ppt_com/constants.py
+++ b/src/ppt_com/constants.py
@@ -306,6 +306,30 @@ ppBulletNumbered = 2
 ppBulletPicture = 3
 
 # ==============================================================================
+# PpNumberedBulletStyle (subset commonly used outside CJK/Hindi/Hebrew/Thai)
+# ==============================================================================
+ppBulletAlphaLCPeriod = 0
+ppBulletAlphaUCPeriod = 1
+ppBulletArabicParenRight = 2
+ppBulletArabicPeriod = 3
+ppBulletRomanLCParenBoth = 4
+ppBulletRomanLCParenRight = 5
+ppBulletRomanLCPeriod = 6
+ppBulletRomanUCPeriod = 7
+ppBulletAlphaLCParenBoth = 8
+ppBulletAlphaLCParenRight = 9
+ppBulletAlphaUCParenBoth = 10
+ppBulletAlphaUCParenRight = 11
+ppBulletArabicParenBoth = 12
+ppBulletArabicPlain = 13
+ppBulletRomanUCParenBoth = 14
+ppBulletRomanUCParenRight = 15
+ppBulletKanjiKoreanPlain = 26
+ppBulletKanjiKoreanPeriod = 27
+ppBulletArabicDBPlain = 28
+ppBulletArabicDBPeriod = 29
+
+# ==============================================================================
 # PpSelectionType
 # ==============================================================================
 ppSelectionNone = 0

--- a/src/ppt_com/text.py
+++ b/src/ppt_com/text.py
@@ -20,6 +20,16 @@ from ppt_com.constants import (
     ppAlignLeft, ppAlignCenter, ppAlignRight, ppAlignJustify, ppAlignDistribute,
     ppAutoSizeNone, ppAutoSizeShapeToFitText, ppAutoSizeTextToFitShape,
     ppBulletNone, ppBulletUnnumbered, ppBulletNumbered,
+    ppBulletAlphaLCPeriod, ppBulletAlphaUCPeriod,
+    ppBulletArabicParenRight, ppBulletArabicPeriod,
+    ppBulletRomanLCParenBoth, ppBulletRomanLCParenRight,
+    ppBulletRomanLCPeriod, ppBulletRomanUCPeriod,
+    ppBulletAlphaLCParenBoth, ppBulletAlphaLCParenRight,
+    ppBulletAlphaUCParenBoth, ppBulletAlphaUCParenRight,
+    ppBulletArabicParenBoth, ppBulletArabicPlain,
+    ppBulletRomanUCParenBoth, ppBulletRomanUCParenRight,
+    ppBulletKanjiKoreanPlain, ppBulletKanjiKoreanPeriod,
+    ppBulletArabicDBPlain, ppBulletArabicDBPeriod,
     msoTextOrientationHorizontal, msoTextOrientationVertical,
     msoTextOrientationUpward, msoTextOrientationDownward,
 )
@@ -86,6 +96,32 @@ BULLET_TYPE_MAP = {
     "none": ppBulletNone,
     "unnumbered": ppBulletUnnumbered,
     "numbered": ppBulletNumbered,
+}
+
+# Curated subset of PpNumberedBulletStyle. CJK/Hindi/Hebrew/Thai variants are
+# omitted; they require corresponding language support in Office and add no
+# value for an LLM-facing API. Add more here if a use case appears.
+NUMBERED_STYLE_MAP = {
+    "arabic_plain":          ppBulletArabicPlain,        # 1 2 3
+    "arabic_period":         ppBulletArabicPeriod,       # 1. 2. 3.
+    "arabic_paren_right":    ppBulletArabicParenRight,   # 1) 2) 3)
+    "arabic_paren_both":     ppBulletArabicParenBoth,    # (1) (2) (3)
+    "arabic_db_plain":       ppBulletArabicDBPlain,      # full-width 1 2 3
+    "arabic_db_period":      ppBulletArabicDBPeriod,     # full-width 1. 2. 3.
+    "alpha_lc_period":       ppBulletAlphaLCPeriod,      # a. b. c.
+    "alpha_uc_period":       ppBulletAlphaUCPeriod,      # A. B. C.
+    "alpha_lc_paren_right":  ppBulletAlphaLCParenRight,  # a) b) c)
+    "alpha_uc_paren_right":  ppBulletAlphaUCParenRight,  # A) B) C)
+    "alpha_lc_paren_both":   ppBulletAlphaLCParenBoth,   # (a) (b) (c)
+    "alpha_uc_paren_both":   ppBulletAlphaUCParenBoth,   # (A) (B) (C)
+    "roman_lc_period":       ppBulletRomanLCPeriod,      # i. ii. iii.
+    "roman_uc_period":       ppBulletRomanUCPeriod,      # I. II. III.
+    "roman_lc_paren_right":  ppBulletRomanLCParenRight,  # i) ii) iii)
+    "roman_uc_paren_right":  ppBulletRomanUCParenRight,  # I) II) III)
+    "roman_lc_paren_both":   ppBulletRomanLCParenBoth,   # (i) (ii) (iii)
+    "roman_uc_paren_both":   ppBulletRomanUCParenBoth,   # (I) (II) (III)
+    "kanji_korean_plain":    ppBulletKanjiKoreanPlain,   # 一 二 三
+    "kanji_korean_period":   ppBulletKanjiKoreanPeriod,  # 一. 二. 三.
 }
 
 
@@ -256,7 +292,7 @@ class SetParagraphFormatInput(BaseModel):
 
 class SetBulletInput(BaseModel):
     """Input for setting bullet/numbering on paragraphs."""
-    model_config = ConfigDict(str_strip_whitespace=True)
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
 
     slide_index: int = Field(..., description="1-based slide index")
     shape_name_or_index: Union[str, int] = Field(
@@ -269,7 +305,8 @@ class SetBulletInput(BaseModel):
         ..., description="'none', 'unnumbered', or 'numbered'"
     )
     bullet_char: Optional[str] = Field(
-        default=None, description="Bullet character (e.g. '●', '■')"
+        default=None, min_length=1,
+        description="Bullet character (e.g. '●', '■')"
     )
     bullet_start_value: Optional[int] = Field(
         default=None, description="Starting number for numbered bullets"
@@ -279,6 +316,68 @@ class SetBulletInput(BaseModel):
         description="Indent level 1-9. Sets the nesting depth of the bullet. "
         "Level 1 = top-level bullet, level 2 = first sub-bullet, etc.",
     )
+    color: Optional[str] = Field(
+        default=None,
+        description="Bullet color as hex (e.g. '#FF0000'). Setting this implicitly disables UseTextColor.",
+    )
+    size: Optional[float] = Field(
+        default=None, ge=0.25, le=4.0,
+        description="Bullet size relative to paragraph text (RelativeSize). 0.25 – 4.0.",
+    )
+    font_name: Optional[str] = Field(
+        default=None, min_length=1,
+        description="Font used to render the bullet glyph (e.g. 'Wingdings'). Setting this implicitly disables UseTextFont.",
+    )
+    numbered_style: Optional[str] = Field(
+        default=None,
+        description=(
+            "Numbered list style alias (PpNumberedBulletStyle). "
+            "When set, bullet_type is forced to 'numbered'. "
+            f"Allowed: {sorted(NUMBERED_STYLE_MAP)}"
+        ),
+    )
+    use_text_color: Optional[bool] = Field(
+        default=None,
+        description="If true, bullet inherits the paragraph text color. Overridden by an explicit color.",
+    )
+    use_text_font: Optional[bool] = Field(
+        default=None,
+        description="If true, bullet inherits the paragraph text font. Overridden by an explicit font_name.",
+    )
+
+    @field_validator("bullet_type")
+    @classmethod
+    def _validate_bullet_type(cls, v):
+        if v not in BULLET_TYPE_MAP:
+            raise ValueError(
+                f"Invalid bullet_type {v!r}. Allowed: {sorted(BULLET_TYPE_MAP)}"
+            )
+        return v
+
+    @field_validator("color")
+    @classmethod
+    def _validate_color(cls, v):
+        if v is None:
+            return v
+        s = v.lstrip("#")
+        if len(s) != 6:
+            raise ValueError(f"color must be a 6-digit hex (got {v!r})")
+        try:
+            int(s, 16)
+        except ValueError as e:
+            raise ValueError(f"color is not valid hex: {v!r}") from e
+        return v
+
+    @field_validator("numbered_style")
+    @classmethod
+    def _validate_numbered_style(cls, v):
+        if v is None:
+            return v
+        if v not in NUMBERED_STYLE_MAP:
+            raise ValueError(
+                f"Invalid numbered_style {v!r}. Allowed: {sorted(NUMBERED_STYLE_MAP)}"
+            )
+        return v
 
 
 class FindReplaceTextInput(BaseModel):
@@ -1312,7 +1411,8 @@ def _set_paragraph_format_impl(slide_index, shape_name_or_index, paragraph_index
 
 def _set_bullet_impl(slide_index, shape_name_or_index, paragraph_index,
                        bullet_type, bullet_char, bullet_start_value,
-                       indent_level) -> dict:
+                       indent_level, color, size, font_name,
+                       numbered_style, use_text_color, use_text_font) -> dict:
     app = ppt._get_app_impl()
     goto_slide(app, slide_index)
     pres = ppt._get_pres_impl()
@@ -1329,12 +1429,9 @@ def _set_bullet_impl(slide_index, shape_name_or_index, paragraph_index,
     else:
         target = tr
 
-    bullet_type_val = BULLET_TYPE_MAP.get(bullet_type)
-    if bullet_type_val is None:
-        raise ValueError(
-            f"Invalid bullet_type '{bullet_type}'. "
-            f"Valid values: {list(BULLET_TYPE_MAP.keys())}"
-        )
+    # numbered_style implies numbered type.
+    effective_type = "numbered" if numbered_style is not None else bullet_type
+    bullet_type_val = BULLET_TYPE_MAP[effective_type]
 
     pf = target.ParagraphFormat
     bullet = pf.Bullet
@@ -1354,12 +1451,38 @@ def _set_bullet_impl(slide_index, shape_name_or_index, paragraph_index,
     if indent_level is not None:
         target.IndentLevel = indent_level
 
+    if numbered_style is not None:
+        bullet.Style = NUMBERED_STYLE_MAP[numbered_style]
+
+    if size is not None:
+        bullet.RelativeSize = size
+
+    # Apply UseText* toggles first; an explicit color/font_name below
+    # supersedes them (setting Font.Color flips UseTextColor to False
+    # automatically per the COM spec).
+    if use_text_color is not None:
+        bullet.UseTextColor = msoTrue if use_text_color else msoFalse
+    if use_text_font is not None:
+        bullet.UseTextFont = msoTrue if use_text_font else msoFalse
+
+    if color is not None:
+        bullet.Font.Color.RGB = hex_to_int(color)
+
+    if font_name is not None:
+        bullet.Font.Name = font_name
+
     return {
         "status": "success",
         "shape_name": shape.Name,
         "paragraph_index": paragraph_index or "all",
-        "bullet_type": bullet_type,
+        "bullet_type": effective_type,
+        "numbered_style": numbered_style,
         "indent_level": indent_level,
+        "color": color,
+        "size": size,
+        "font_name": font_name,
+        "use_text_color": use_text_color,
+        "use_text_font": use_text_font,
     }
 
 
@@ -1610,13 +1733,14 @@ def set_paragraph_format(params: SetParagraphFormatInput) -> str:
 
 
 def set_bullet(params: SetBulletInput) -> str:
-    """Set bullet/numbering for paragraphs in a shape."""
+    """Set bullet/numbering and appearance for paragraphs in a shape."""
     try:
         result = ppt.execute(
             _set_bullet_impl,
             params.slide_index, params.shape_name_or_index, params.paragraph_index,
             params.bullet_type, params.bullet_char, params.bullet_start_value,
-            params.indent_level,
+            params.indent_level, params.color, params.size, params.font_name,
+            params.numbered_style, params.use_text_color, params.use_text_font,
         )
         return json.dumps(result)
     except Exception as e:
@@ -2204,19 +2328,27 @@ def register_tools(mcp):
         },
     )
     async def tool_ppt_set_bullet(params: SetBulletInput) -> str:
-        """Set bullet or numbering for paragraphs in a shape.
+        """Set bullet/numbering and appearance for paragraphs in a shape.
 
-        bullet_type can be 'none', 'unnumbered', or 'numbered'.
-        Use bullet_char for custom bullet characters (e.g. '●').
-        Use bullet_start_value to set the starting number.
-        Use indent_level (1-9) to set nesting depth in one call.
+        Core:
+        - bullet_type: 'none', 'unnumbered', or 'numbered'.
+        - bullet_char: custom symbol (e.g. '●').
+        - bullet_start_value: starting number for numbered lists.
+        - indent_level (1-9): nesting depth.
+
+        Appearance:
+        - color: hex like '#FF0000'. Setting this flips UseTextColor to False
+          automatically (COM behavior).
+        - size: RelativeSize 0.25–4.0 (text-size ratio).
+        - font_name: glyph font (e.g. 'Wingdings').
+        - numbered_style: PpNumberedBulletStyle alias such as 'arabic_period',
+          'roman_uc_period', 'kanji_korean_period'. Implies bullet_type='numbered'.
+        - use_text_color / use_text_font: inherit the paragraph's color/font.
 
         Nested bullet example — first use ppt_set_text to create paragraphs
-        separated by \\n, then call ppt_set_bullet per paragraph
-        (slide_index and shape_name_or_index required on each call):
+        separated by \\n, then call ppt_set_bullet per paragraph:
           ppt_set_bullet(..., paragraph_index=1, bullet_type='unnumbered', indent_level=1)
           ppt_set_bullet(..., paragraph_index=2, bullet_type='unnumbered', indent_level=2)
-          ppt_set_bullet(..., paragraph_index=3, bullet_type='unnumbered', indent_level=3)
         """
         return set_bullet(params)
 

--- a/src/ppt_com/text.py
+++ b/src/ppt_com/text.py
@@ -292,6 +292,10 @@ class SetParagraphFormatInput(BaseModel):
 
 class SetBulletInput(BaseModel):
     """Input for setting bullet/numbering on paragraphs."""
+    # extra='forbid' so typos like `font_nme` fail loudly at the MCP
+    # boundary instead of being silently dropped. Silent drops would mask
+    # the appearance change the caller intended and ship a bullet that
+    # doesn't match expectations.
     model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
 
     slide_index: int = Field(..., description="1-based slide index")
@@ -318,7 +322,11 @@ class SetBulletInput(BaseModel):
     )
     color: Optional[str] = Field(
         default=None,
-        description="Bullet color as hex (e.g. '#FF0000'). Setting this implicitly disables UseTextColor.",
+        description=(
+            "Bullet color as hex, with or without leading '#' "
+            "(e.g. '#FF0000' or 'FF0000'). Setting this implicitly disables "
+            "UseTextColor."
+        ),
     )
     size: Optional[float] = Field(
         default=None, ge=0.25, le=4.0,
@@ -378,6 +386,16 @@ class SetBulletInput(BaseModel):
                 f"Invalid numbered_style {v!r}. Allowed: {sorted(NUMBERED_STYLE_MAP)}"
             )
         return v
+
+    @model_validator(mode="after")
+    def _coerce_bullet_type_when_numbered_style_set(self):
+        """numbered_style implies a numbered list — coerce here so the
+        returned schema reflects the actual effect instead of having
+        _set_bullet_impl silently override the caller's bullet_type.
+        """
+        if self.numbered_style is not None and self.bullet_type != "numbered":
+            self.bullet_type = "numbered"
+        return self
 
 
 class FindReplaceTextInput(BaseModel):
@@ -1429,9 +1447,9 @@ def _set_bullet_impl(slide_index, shape_name_or_index, paragraph_index,
     else:
         target = tr
 
-    # numbered_style implies numbered type.
-    effective_type = "numbered" if numbered_style is not None else bullet_type
-    bullet_type_val = BULLET_TYPE_MAP[effective_type]
+    # bullet_type has already been coerced to "numbered" at the Pydantic
+    # layer when numbered_style is set, so we can trust it here.
+    bullet_type_val = BULLET_TYPE_MAP[bullet_type]
 
     pf = target.ParagraphFormat
     bullet = pf.Bullet
@@ -1471,18 +1489,25 @@ def _set_bullet_impl(slide_index, shape_name_or_index, paragraph_index,
     if font_name is not None:
         bullet.Font.Name = font_name
 
+    # When an explicit color or font_name is provided, COM flips the
+    # corresponding UseText* flag back to False. Reflect that effective state
+    # in the response so callers see what COM actually applied, not what
+    # they asked for.
+    effective_use_text_color = False if color is not None else use_text_color
+    effective_use_text_font = False if font_name is not None else use_text_font
+
     return {
         "status": "success",
         "shape_name": shape.Name,
         "paragraph_index": paragraph_index or "all",
-        "bullet_type": effective_type,
+        "bullet_type": bullet_type,
         "numbered_style": numbered_style,
         "indent_level": indent_level,
         "color": color,
         "size": size,
         "font_name": font_name,
-        "use_text_color": use_text_color,
-        "use_text_font": use_text_font,
+        "use_text_color": effective_use_text_color,
+        "use_text_font": effective_use_text_font,
     }
 
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -2669,6 +2669,23 @@ class TestSetBulletAppearance:
         with pytest.raises(ValidationError):
             self._ok(definitely_not_a_field=True)
 
+    def test_bullet_char_empty_rejected(self):
+        """bullet_char has min_length=1 — empty string must be rejected."""
+        with pytest.raises(ValidationError):
+            self._ok(bullet_char="")
+
+    def test_numbered_style_coerces_bullet_type_to_numbered(self):
+        """numbered_style is meaningless without numbered type — coerce at
+        the Pydantic layer so the response reflects the actual effect."""
+        inp = self._ok(bullet_type="none", numbered_style="arabic_period")
+        assert inp.bullet_type == "numbered"
+        assert inp.numbered_style == "arabic_period"
+
+    def test_numbered_style_leaves_explicit_numbered_alone(self):
+        inp = self._ok(bullet_type="numbered", numbered_style="roman_lc_period")
+        assert inp.bullet_type == "numbered"
+        assert inp.numbered_style == "roman_lc_period"
+
 
 # ============================================================================
 # text.py — SetParagraphFormatInput

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -2591,6 +2591,84 @@ class TestSetBulletInput:
             )
 
 
+class TestSetBulletAppearance:
+    """Tests for the appearance fields added in issue #154."""
+
+    def _ok(self, **overrides):
+        kwargs = dict(slide_index=1, shape_name_or_index="Shape1", bullet_type="unnumbered")
+        kwargs.update(overrides)
+        return SetBulletInput(**kwargs)
+
+    def test_defaults_are_none(self):
+        inp = self._ok()
+        assert inp.color is None
+        assert inp.size is None
+        assert inp.font_name is None
+        assert inp.numbered_style is None
+        assert inp.use_text_color is None
+        assert inp.use_text_font is None
+
+    def test_bullet_type_invalid_rejected(self):
+        with pytest.raises(ValidationError, match="Invalid bullet_type"):
+            self._ok(bullet_type="bogus")
+
+    def test_color_hex_with_hash(self):
+        inp = self._ok(color="#FF0080")
+        assert inp.color == "#FF0080"
+
+    def test_color_hex_without_hash(self):
+        inp = self._ok(color="FF0080")
+        assert inp.color == "FF0080"
+
+    def test_color_invalid_length_rejected(self):
+        with pytest.raises(ValidationError, match="6-digit hex"):
+            self._ok(color="#FFF")
+
+    def test_color_invalid_chars_rejected(self):
+        with pytest.raises(ValidationError, match="not valid hex"):
+            self._ok(color="#ZZZZZZ")
+
+    def test_size_in_range(self):
+        assert self._ok(size=0.25).size == 0.25
+        assert self._ok(size=4.0).size == 4.0
+        assert self._ok(size=1.5).size == 1.5
+
+    def test_size_out_of_range_rejected(self):
+        with pytest.raises(ValidationError):
+            self._ok(size=0.1)
+        with pytest.raises(ValidationError):
+            self._ok(size=4.5)
+
+    def test_font_name_min_length(self):
+        with pytest.raises(ValidationError):
+            self._ok(font_name="")
+
+    def test_numbered_style_valid(self):
+        inp = self._ok(numbered_style="arabic_period")
+        assert inp.numbered_style == "arabic_period"
+
+    def test_numbered_style_invalid_rejected(self):
+        with pytest.raises(ValidationError, match="Invalid numbered_style"):
+            self._ok(numbered_style="not_a_style")
+
+    def test_numbered_style_alias_coverage(self):
+        """Spot-check that the 4 most useful aliases are accepted."""
+        for alias in ("arabic_period", "alpha_uc_period", "roman_lc_period", "kanji_korean_period"):
+            assert self._ok(numbered_style=alias).numbered_style == alias
+
+    def test_use_text_color_bool(self):
+        assert self._ok(use_text_color=True).use_text_color is True
+        assert self._ok(use_text_color=False).use_text_color is False
+
+    def test_use_text_font_bool(self):
+        assert self._ok(use_text_font=True).use_text_font is True
+        assert self._ok(use_text_font=False).use_text_font is False
+
+    def test_unknown_field_rejected(self):
+        with pytest.raises(ValidationError):
+            self._ok(definitely_not_a_field=True)
+
+
 # ============================================================================
 # text.py — SetParagraphFormatInput
 # ============================================================================


### PR DESCRIPTION
## Summary
Extend `ppt_set_bullet` so bullet appearance can be customized — color, relative size, glyph font, numbered-list style, and whether color/font follow the paragraph text.

## Schema additions (`SetBulletInput`)
| Field | COM property | Notes |
|------|------|------|
| `color: Optional[str]` | `Font.Color.RGB` | hex like `#FF0080`, converted to BGR |
| `size: Optional[float]` | `RelativeSize` | 0.25 – 4.0 (text-size ratio) |
| `font_name: Optional[str]` | `Font.Name` | e.g. `Wingdings` |
| `numbered_style: Optional[str]` | `Style` | curated alias → `PpNumberedBulletStyle` (forces `bullet_type='numbered'`) |
| `use_text_color: Optional[bool]` | `UseTextColor` | inherit paragraph text color |
| `use_text_font: Optional[bool]` | `UseTextFont` | inherit paragraph text font |

Also set `extra='forbid'` on `SetBulletInput` so future typos fail loudly.

### `numbered_style` aliases (curated 20)
`arabic_plain` / `arabic_period` / `arabic_paren_right` / `arabic_paren_both` / `arabic_db_plain` / `arabic_db_period` / `alpha_lc_period` / `alpha_uc_period` / `alpha_lc_paren_right` / `alpha_uc_paren_right` / `alpha_lc_paren_both` / `alpha_uc_paren_both` / `roman_lc_period` / `roman_uc_period` / `roman_lc_paren_right` / `roman_uc_paren_right` / `roman_lc_paren_both` / `roman_uc_paren_both` / `kanji_korean_plain` / `kanji_korean_period`

## Refs
- https://learn.microsoft.com/en-us/office/vba/api/powerpoint.bulletformat
- https://learn.microsoft.com/en-us/office/vba/api/powerpoint.bulletformat.relativesize
- https://learn.microsoft.com/en-us/office/vba/api/powerpoint.ppnumberedbulletstyle

## Test plan
- [x] `uv run pytest` — 506 passed (15 new validator tests for the appearance fields)
- [x] `bash scripts/count_tools.sh` — total still 154 (no new tool added)
- [x] Manual against live PowerPoint:
  - Slide 1: pink `●` at 1.5× size — text stays default color/size ✓
  - Slide 2: blue `1. 2. 3.` `arabic_period` at 1.2× ✓
  - Slide 3: `一. 二. 三. 四.` `kanji_korean_period` with `use_text_color=true, use_text_font=true` ✓
  - Wingdings smiley glyph (`bullet_char='J', font_name='Wingdings'`) in green ✓

## Out of scope
- Picture bullets (`Bullet.Picture(path)`) — tracked as future work.

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)