### PR TITLE
Release v1.3.0

### DIFF
--- a/README_ja.md
+++ b/README_ja.md
@@ -14,7 +14,7 @@
 </p>
 
 <p align="center">
-  <strong>COM自動化によるPowerPointのリアルタイム制御 —<br>AIエージェントと開発者のための154ツールを備えたMCPサーバー</strong>
+  <strong>COM自動化によるPowerPointのリアルタイム制御 —<br>AIエージェントと開発者のための155ツールを備えたMCPサーバー</strong>
 </p>
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ppt-mcp"
-version = "1.2.0"
-description = "Real-time PowerPoint control via COM automation — an MCP server with 154 tools for AI agents"
+version = "1.3.0"
+description = "Real-time PowerPoint control via COM automation — an MCP server with 155 tools for AI agents"
 readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"


### PR DESCRIPTION
Bumps the version to **v1.3.0** so the `ppt_format_chart_axis` tool added in #159 can be published to PyPI.

## Changes since v1.2.0

- feat(charts): add `ppt_format_chart_axis` tool for axis scale, ticks, labels (#159)

## Release notes (minor bump)

- New tool `ppt_format_chart_axis` covering axis title, min/max scale, major/minor unit, tick spacing (category axis), tick mark style, log scale, reverse order, tick-label font size, and number format.
- Total tool count: 154 → 155.

## Post-merge

After merging, pushing tag `v1.3.0` on `main` will trigger `publish.yml` to publish the wheel/sdist to PyPI via Trusted Publishing.