### PR TITLE
feat: add like_slide_index to ppt_add_slide + layout ambiguity warning (#161)

### DIFF
--- a/src/ppt_com/slides.py
+++ b/src/ppt_com/slides.py
@@ -5,7 +5,7 @@ Add, delete, duplicate, move, list, and query slides. Manage speaker notes.
 
 import json
 import logging
-from typing import Optional
+from typing import NamedTuple, Optional
 
 from pydantic import BaseModel, Field, ConfigDict
 
@@ -278,12 +278,19 @@ def _resolve_presentation(
 # ---------------------------------------------------------------------------
 # Implementation functions (run on COM thread via ppt.execute)
 # ---------------------------------------------------------------------------
+class _LayoutMatch(NamedTuple):
+    """One design that contains a custom layout with the requested name."""
+    design_index: int
+    design_name: str
+    custom_layout: object
+
+
 def _find_layout_matches(pres, layout_name: str, design_index: Optional[int]):
     """Find custom layouts matching ``layout_name`` across designs.
 
-    Returns a list of (design_index, design_name, custom_layout) tuples — one
-    per design that contains a layout with that exact name. When design_index
-    is given, only that design is searched.
+    Returns a list of _LayoutMatch (design_index, design_name, custom_layout) —
+    one per design that contains a layout with that exact name. When
+    design_index is given, only that design is searched.
     """
     if design_index is not None:
         search = [design_index]
@@ -297,7 +304,7 @@ def _find_layout_matches(pres, layout_name: str, design_index: Optional[int]):
         for i in range(1, master.CustomLayouts.Count + 1):
             lay = master.CustomLayouts(i)
             if lay.Name == layout_name:
-                matches.append((d, design.Name, lay))
+                matches.append(_LayoutMatch(d, design.Name, lay))
                 break  # at most one layout of a given name per design
     return matches
 
@@ -381,21 +388,25 @@ def _add_slide_impl(
 
             # Prefer the default master's design when the name is ambiguous,
             # matching the historical selection order (default master first).
+            # Tiebreak is by master name; in the rare case two designs share a
+            # master name the pick may differ, but the ambiguity warning below
+            # lists every candidate so the caller can override with
+            # design_index or like_slide_index.
             chosen = matches[0]
             if len(matches) > 1:
                 try:
                     default_master_name = pres.SlideMaster.Name
                     for mt in matches:
-                        if pres.Designs(mt[0]).SlideMaster.Name == default_master_name:
+                        if pres.Designs(mt.design_index).SlideMaster.Name == default_master_name:
                             chosen = mt
                             break
                 except Exception:
                     pass
                 layout_ambiguous = True
-                ambiguous_designs = [m[1] for m in matches]
+                ambiguous_designs = [m.design_name for m in matches]
 
-            custom_layout = chosen[2]
-            resolved_design_name = chosen[1]
+            custom_layout = chosen.custom_layout
+            resolved_design_name = chosen.design_name
             use_custom_layout = True
             resolved_layout_name = custom_layout.Name
     else:
@@ -421,7 +432,6 @@ def _add_slide_impl(
 
     # Read actual layout from the first created slide
     first_slide = pres.Slides(created_slides[0]["slide_index"])
-    resp_layout = resolved_layout_name if resolved_layout_name else first_slide.Layout
 
     # Resolve the actually-applied layout/design names for caller verification.
     final_layout_name = resolved_layout_name
@@ -438,7 +448,9 @@ def _add_slide_impl(
         "success": True,
         "slides_created": len(created_slides),
         "slides": created_slides,
-        "layout": resp_layout,
+        # "layout" is always the PpSlideLayout integer constant; the
+        # human-readable custom layout name is in "layout_name".
+        "layout": first_slide.Layout,
         "layout_name": final_layout_name,
         "design_name": final_design_name,
     }

--- a/src/ppt_com/slides.py
+++ b/src/ppt_com/slides.py
@@ -71,6 +71,18 @@ class AddSlideInput(BaseModel):
             "then all designs."
         ),
     )
+    like_slide_index: Optional[int] = Field(
+        default=None,
+        description=(
+            "1-based index of an existing slide to copy the design + layout from. "
+            "Inherits that slide's exact CustomLayout (design/master AND layout), "
+            "so the new slide looks like it without any layout-name ambiguity. "
+            "This is the most reliable way to 'add a slide like this one'. "
+            "Takes precedence over layout, layout_name, and design_index. "
+            "Note: this inherits the look only — it does NOT copy the slide's "
+            "content/shapes (use ppt_duplicate_slide for a full copy)."
+        ),
+    )
     count: int = Field(
         default=1,
         ge=1,
@@ -266,12 +278,37 @@ def _resolve_presentation(
 # ---------------------------------------------------------------------------
 # Implementation functions (run on COM thread via ppt.execute)
 # ---------------------------------------------------------------------------
+def _find_layout_matches(pres, layout_name: str, design_index: Optional[int]):
+    """Find custom layouts matching ``layout_name`` across designs.
+
+    Returns a list of (design_index, design_name, custom_layout) tuples — one
+    per design that contains a layout with that exact name. When design_index
+    is given, only that design is searched.
+    """
+    if design_index is not None:
+        search = [design_index]
+    else:
+        search = range(1, pres.Designs.Count + 1)
+
+    matches = []
+    for d in search:
+        design = pres.Designs(d)
+        master = design.SlideMaster
+        for i in range(1, master.CustomLayouts.Count + 1):
+            lay = master.CustomLayouts(i)
+            if lay.Name == layout_name:
+                matches.append((d, design.Name, lay))
+                break  # at most one layout of a given name per design
+    return matches
+
+
 def _add_slide_impl(
     position: Optional[int],
     layout: Optional[int],
     layout_name: Optional[str],
     design_index: Optional[int] = None,
     count: int = 1,
+    like_slide_index: Optional[int] = None,
 ) -> dict:
     app = ppt._get_app_impl()
     pres = _resolve_presentation(app)
@@ -290,44 +327,44 @@ def _add_slide_impl(
     friendly_layout = None
     layout_val = None
     resolved_layout_name = None
+    resolved_design_name = None
+    layout_ambiguous = False
+    ambiguous_designs = None
 
-    if layout_name:
+    if like_slide_index is not None:
+        # Highest precedence: inherit the exact CustomLayout (design + layout)
+        # of an existing slide. Using the object reference directly means there
+        # is no layout-name ambiguity across designs.
+        if like_slide_index < 1 or like_slide_index > pres.Slides.Count:
+            raise ValueError(
+                f"like_slide_index {like_slide_index} out of range "
+                f"(1-{pres.Slides.Count})"
+            )
+        src_slide = pres.Slides(like_slide_index)
+        custom_layout = src_slide.CustomLayout
+        use_custom_layout = True
+        resolved_layout_name = custom_layout.Name
+        try:
+            resolved_design_name = src_slide.Design.Name
+        except Exception:
+            resolved_design_name = None
+    elif layout_name:
         # Check friendly name map first
         friendly_key = layout_name.lower().strip().replace(" ", "_")
         if friendly_key in LAYOUT_NAME_MAP:
             friendly_layout = LAYOUT_NAME_MAP[friendly_key]
         else:
-            if design_index is not None:
-                # Search in the specified design
-                if design_index < 1 or design_index > pres.Designs.Count:
-                    raise ValueError(
-                        f"Design index {design_index} out of range "
-                        f"(1-{pres.Designs.Count})"
-                    )
-                master = pres.Designs(design_index).SlideMaster
-                for i in range(1, master.CustomLayouts.Count + 1):
-                    if master.CustomLayouts(i).Name == layout_name:
-                        custom_layout = master.CustomLayouts(i)
-                        break
-            else:
-                # Search default master first, then all designs
-                master = pres.SlideMaster
-                for i in range(1, master.CustomLayouts.Count + 1):
-                    if master.CustomLayouts(i).Name == layout_name:
-                        custom_layout = master.CustomLayouts(i)
-                        break
+            if design_index is not None and (
+                design_index < 1 or design_index > pres.Designs.Count
+            ):
+                raise ValueError(
+                    f"Design index {design_index} out of range "
+                    f"(1-{pres.Designs.Count})"
+                )
 
-                if custom_layout is None:
-                    for d in range(1, pres.Designs.Count + 1):
-                        m = pres.Designs(d).SlideMaster
-                        for i in range(1, m.CustomLayouts.Count + 1):
-                            if m.CustomLayouts(i).Name == layout_name:
-                                custom_layout = m.CustomLayouts(i)
-                                break
-                        if custom_layout is not None:
-                            break
+            matches = _find_layout_matches(pres, layout_name, design_index)
 
-            if custom_layout is None:
+            if not matches:
                 # Collect available layouts for error message
                 available = {}
                 for d in range(1, pres.Designs.Count + 1):
@@ -341,6 +378,24 @@ def _add_slide_impl(
                     f"Layout '{layout_name}' not found. "
                     f"Available custom layouts by design: {available}"
                 )
+
+            # Prefer the default master's design when the name is ambiguous,
+            # matching the historical selection order (default master first).
+            chosen = matches[0]
+            if len(matches) > 1:
+                try:
+                    default_master_name = pres.SlideMaster.Name
+                    for mt in matches:
+                        if pres.Designs(mt[0]).SlideMaster.Name == default_master_name:
+                            chosen = mt
+                            break
+                except Exception:
+                    pass
+                layout_ambiguous = True
+                ambiguous_designs = [m[1] for m in matches]
+
+            custom_layout = chosen[2]
+            resolved_design_name = chosen[1]
             use_custom_layout = True
             resolved_layout_name = custom_layout.Name
     else:
@@ -368,12 +423,36 @@ def _add_slide_impl(
     first_slide = pres.Slides(created_slides[0]["slide_index"])
     resp_layout = resolved_layout_name if resolved_layout_name else first_slide.Layout
 
+    # Resolve the actually-applied layout/design names for caller verification.
+    final_layout_name = resolved_layout_name
+    final_design_name = resolved_design_name
+    try:
+        if final_layout_name is None:
+            final_layout_name = first_slide.CustomLayout.Name
+        if final_design_name is None:
+            final_design_name = first_slide.Design.Name
+    except Exception:
+        pass
+
     result = {
         "success": True,
         "slides_created": len(created_slides),
         "slides": created_slides,
         "layout": resp_layout,
+        "layout_name": final_layout_name,
+        "design_name": final_design_name,
     }
+
+    # Surface ambiguous layout-name matches so callers can detect a possible
+    # wrong-design selection (the issue's core failure mode).
+    if layout_ambiguous:
+        result["layout_ambiguous"] = True
+        result["warning"] = (
+            f"Layout '{layout_name}' exists in multiple designs "
+            f"({', '.join(ambiguous_designs)}); used design "
+            f"'{final_design_name}'. Pass design_index or like_slide_index "
+            f"to select a specific one."
+        )
 
     # Backward compatibility: include top-level slide_index/slide_id for count=1
     if count == 1:
@@ -614,6 +693,7 @@ def add_slide(params: AddSlideInput) -> str:
         result = ppt.execute(
             _add_slide_impl, params.position, params.layout,
             params.layout_name, params.design_index, params.count,
+            params.like_slide_index,
         )
         return json.dumps(result)
     except Exception as e:
@@ -752,13 +832,22 @@ def register_tools(mcp):
     async def tool_add_slide(params: AddSlideInput) -> str:
         """Add a new slide to the active presentation.
 
-        Specify a layout by name (e.g. 'blank', 'title', 'title_only') or
-        by PpSlideLayout integer constant. You can also provide a custom
+        To add a slide that looks just like an existing one, pass
+        like_slide_index — it inherits that slide's exact design + layout with
+        no layout-name ambiguity (this only copies the look, not the content;
+        use ppt_duplicate_slide for a full copy). This is the recommended path.
+
+        Otherwise specify a layout by name (e.g. 'blank', 'title', 'title_only')
+        or by PpSlideLayout integer constant. You can also provide a custom
         layout_name to match a layout from the slide master.
         Position is 1-based; omit to append at the end.
         Use design_index to pick a layout from a specific slide master/design.
         Use count to create multiple slides at once; when count > 1, returns
         a slides list instead of a single slide_index.
+
+        The response includes the actually-applied layout_name and design_name.
+        If layout_name matched layouts in multiple designs, the response also
+        includes layout_ambiguous=true and a warning naming the candidates.
         """
         return add_slide(params)
 

--- a/src/ppt_com/slides.py
+++ b/src/ppt_com/slides.py
@@ -372,9 +372,17 @@ def _add_slide_impl(
             matches = _find_layout_matches(pres, layout_name, design_index)
 
             if not matches:
-                # Collect available layouts for error message
+                # Collect available layouts for the error message, scoped to
+                # the same designs that were actually searched — otherwise a
+                # design_index lookup would list layouts from unrelated designs
+                # (including the one where the name does exist), contradicting
+                # the "not found" message.
+                error_search = (
+                    [design_index] if design_index is not None
+                    else range(1, pres.Designs.Count + 1)
+                )
                 available = {}
-                for d in range(1, pres.Designs.Count + 1):
+                for d in error_search:
                     design = pres.Designs(d)
                     m = design.SlideMaster
                     names = []

--- a/tests/test_slides_layout.py
+++ b/tests/test_slides_layout.py
@@ -1,0 +1,111 @@
+"""Tests for slide layout/design resolution helpers (issue #161).
+
+Pure Python tests — a fake COM presentation mimics the Designs / SlideMaster /
+CustomLayouts object graph so the name-matching logic can be verified without
+PowerPoint.
+"""
+
+import sys
+
+sys.path.insert(0, "src")
+
+import pytest
+
+from ppt_com.slides import AddSlideInput, _find_layout_matches
+
+
+# --- Fake COM object graph -------------------------------------------------
+
+class _FakeLayout:
+    def __init__(self, name):
+        self.Name = name
+
+
+class _FakeCollection:
+    """1-based collection callable like a COM collection: coll(i)."""
+
+    def __init__(self, items):
+        self._items = items
+
+    @property
+    def Count(self):
+        return len(self._items)
+
+    def __call__(self, i):
+        return self._items[i - 1]
+
+
+class _FakeMaster:
+    def __init__(self, layout_names):
+        self.CustomLayouts = _FakeCollection([_FakeLayout(n) for n in layout_names])
+
+
+class _FakeDesign:
+    def __init__(self, name, layout_names):
+        self.Name = name
+        self.SlideMaster = _FakeMaster(layout_names)
+
+
+class _FakePres:
+    def __init__(self, designs):
+        # designs: list of (design_name, [layout_names])
+        self.Designs = _FakeCollection(
+            [_FakeDesign(n, ls) for n, ls in designs]
+        )
+
+
+# --- AddSlideInput model ---------------------------------------------------
+
+def test_like_slide_index_accepted():
+    m = AddSlideInput(like_slide_index=3)
+    assert m.like_slide_index == 3
+
+
+def test_like_slide_index_defaults_none():
+    m = AddSlideInput()
+    assert m.like_slide_index is None
+
+
+# --- _find_layout_matches --------------------------------------------------
+
+def _pres():
+    return _FakePres([
+        ("Design A", ["Title", "Title Only", "Content"]),
+        ("Design B", ["Title Only", "Two Content"]),
+        ("Design C", ["Section Header"]),
+    ])
+
+
+def test_single_match_returns_one():
+    matches = _find_layout_matches(_pres(), "Content", None)
+    assert [(m[0], m[1]) for m in matches] == [(1, "Design A")]
+
+
+def test_ambiguous_match_across_designs():
+    matches = _find_layout_matches(_pres(), "Title Only", None)
+    # Present in Design A (1) and Design B (2)
+    assert [(m[0], m[1]) for m in matches] == [(1, "Design A"), (2, "Design B")]
+    assert len(matches) > 1  # caller flags this as ambiguous
+
+
+def test_no_match_returns_empty():
+    assert _find_layout_matches(_pres(), "Nonexistent", None) == []
+
+
+def test_design_index_restricts_search():
+    # "Title Only" exists in both A and B, but searching only design 2 -> B
+    matches = _find_layout_matches(_pres(), "Title Only", 2)
+    assert [(m[0], m[1]) for m in matches] == [(2, "Design B")]
+
+
+def test_design_index_no_match_in_that_design():
+    # "Content" only exists in design 1; restricting to design 3 -> none
+    assert _find_layout_matches(_pres(), "Content", 3) == []
+
+
+def test_at_most_one_match_per_design():
+    # A design with the same layout name twice should still yield one match.
+    pres = _FakePres([("Dup", ["X", "X", "Y"])])
+    matches = _find_layout_matches(pres, "X", None)
+    assert len(matches) == 1
+    assert matches[0][1] == "Dup"

--- a/tests/test_slides_layout.py
+++ b/tests/test_slides_layout.py
@@ -83,13 +83,15 @@ def _pres():
 
 def test_single_match_returns_one():
     matches = _find_layout_matches(_pres(), "Content", None)
-    assert [(m[0], m[1]) for m in matches] == [(1, "Design A")]
+    assert [(m.design_index, m.design_name) for m in matches] == [(1, "Design A")]
 
 
 def test_ambiguous_match_across_designs():
     matches = _find_layout_matches(_pres(), "Title Only", None)
     # Present in Design A (1) and Design B (2)
-    assert [(m[0], m[1]) for m in matches] == [(1, "Design A"), (2, "Design B")]
+    assert [(m.design_index, m.design_name) for m in matches] == [
+        (1, "Design A"), (2, "Design B")
+    ]
     assert len(matches) > 1  # caller flags this as ambiguous
 
 
@@ -100,7 +102,7 @@ def test_no_match_returns_empty():
 def test_design_index_restricts_search():
     # "Title Only" exists in both A and B, but searching only design 2 -> B
     matches = _find_layout_matches(_pres(), "Title Only", 2)
-    assert [(m[0], m[1]) for m in matches] == [(2, "Design B")]
+    assert [(m.design_index, m.design_name) for m in matches] == [(2, "Design B")]
 
 
 def test_design_index_no_match_in_that_design():
@@ -113,4 +115,4 @@ def test_at_most_one_match_per_design():
     pres = _FakePres([("Dup", ["X", "X", "Y"])])
     matches = _find_layout_matches(pres, "X", None)
     assert len(matches) == 1
-    assert matches[0][1] == "Dup"
+    assert matches[0].design_name == "Dup"

--- a/tests/test_slides_layout.py
+++ b/tests/test_slides_layout.py
@@ -9,8 +9,6 @@ import sys
 
 sys.path.insert(0, "src")
 
-import pytest
-
 from ppt_com.slides import AddSlideInput, _find_layout_matches
 
 
@@ -64,6 +62,13 @@ def test_like_slide_index_accepted():
 def test_like_slide_index_defaults_none():
     m = AddSlideInput()
     assert m.like_slide_index is None
+
+
+def test_like_slide_index_zero_accepted_by_model():
+    # The model intentionally has no ge=1 constraint — the 1-based bounds
+    # check is enforced at runtime in _add_slide_impl, not at the model level.
+    m = AddSlideInput(like_slide_index=0)
+    assert m.like_slide_index == 0
 
 
 # --- _find_layout_matches --------------------------------------------------


### PR DESCRIPTION
## Summary

Adding "a slide that looks just like an existing one" was hard to do in the shortest path and could silently pick a layout from the **wrong design** when the same layout name exists in multiple slide masters (a common situation in rich templates).

This PR solves the problem generally by letting callers reference an existing slide's exact `CustomLayout` object — which encodes **both** the design (master/theme) **and** the layout — so there is zero name-resolution ambiguity.

## Changes

- **New `like_slide_index` param on `ppt_add_slide`** (highest precedence). Inherits the source slide's design + layout via its `CustomLayout`. Inherits the *look only*, not the content — `ppt_duplicate_slide` remains the full-copy tool.
- The `ppt_add_slide` response now **always reports the actually-applied `layout_name` and `design_name`**.
- When `layout_name` matches layouts in **multiple designs** (and no `design_index` is given), the response includes `layout_ambiguous: true` and a `warning` naming the candidate designs, so a wrong selection is detectable. The chosen design still prefers the default master (preserves prior behavior).

### Design note
Why `like_slide_index` (the issue's Option A) over name-based resolution: passing the `CustomLayout` object reference directly to `Slides.AddSlide` bypasses name lookup entirely, so duplicate layout names across designs can't cause a wrong pick. I deliberately did **not** add a separate `prefer_active_design` flag (the issue's Option B) — once `like_slide_index` exists it is redundant API surface.

No new tool (parameter added to an existing tool, per the tool-count policy). No README/tool-count change.

## Tests

- `tests/test_slides_layout.py` (8 new): input model + `_find_layout_matches` resolver (single / ambiguous-across-designs / no-match / design-scoped / per-design dedup) using a fake COM presentation. Full suite: **524 passed**.
- **Verified live** against a 13-design template where layout name `4画像 2×2` exists in 3 designs:
  - `like_slide_index=5` → inherited design `画像と文字` + layout `4画像 2×2` (confirmed by response and slide preview).
  - `layout_name="4画像 2×2"` → `layout_ambiguous: true` with a warning listing all 3 candidate designs.

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)