### PR TITLE
fix: bulk slide move for non-contiguous selections straddling target

### DIFF
--- a/src/ppt_com/slides.py
+++ b/src/ppt_com/slides.py
@@ -840,18 +840,32 @@ def _move_slide_impl(
 
     nav_goto_slide(app, sources[0])
 
-    # Anchor on SlideIDs because indices shift as we move. The j-th slide (in
-    # original order) must end up at new_position + j. MoveTo uses final-position
-    # semantics, so the iteration order depends on direction: a backward move
-    # (target at/below the block) places front-to-back; a forward move places
-    # back-to-front. Otherwise already-placed slides get displaced.
+    # Build the FULL desired final order of slide IDs, then realize it. A
+    # direction heuristic based on sources[0] is not enough: a non-contiguous
+    # selection that straddles the target can leave a member outside the block
+    # (e.g. [1,4,5] -> position 2). Instead, lay out the final order explicitly —
+    # the selected slides (in original order) occupy positions
+    # new_position .. new_position+k-1, and the unselected slides keep their
+    # relative order around them.
     src_ids = [pres.Slides(i).SlideID for i in sources]
-    order = range(k) if new_position <= sources[0] else range(k - 1, -1, -1)
-    for j in order:
-        cur_idx = pres.Slides.FindBySlideID(src_ids[j]).SlideIndex
-        target = new_position + j
-        if cur_idx != target:
-            pres.Slides(cur_idx).MoveTo(toPos=target)
+    selected = set(src_ids)
+    others = [
+        pres.Slides(i).SlideID
+        for i in range(1, total + 1)
+        if pres.Slides(i).SlideID not in selected
+    ]
+    final_ids = (
+        others[: new_position - 1] + src_ids + others[new_position - 1:]
+    )
+
+    # Realize the target order left-to-right. Invariant: once we reach position
+    # f, positions 1..f-1 already hold their final slide, so the slide wanted at
+    # f is necessarily at some index >= f. MoveTo(f) then shifts only positions
+    # >= f, never disturbing what is already placed.
+    for f in range(1, total + 1):
+        cur_idx = pres.Slides.FindBySlideID(final_ids[f - 1]).SlideIndex
+        if cur_idx != f:
+            pres.Slides(cur_idx).MoveTo(toPos=f)
 
     result = {
         "success": True,

--- a/src/ppt_com/slides.py
+++ b/src/ppt_com/slides.py
@@ -811,6 +811,20 @@ def _duplicate_slide_impl(
     return result
 
 
+def _compute_final_order(all_ids: list, src_ids: list, new_position: int) -> list:
+    """Compute the desired final order of slide IDs for a bulk move.
+
+    ``all_ids`` is every slide ID in current order; ``src_ids`` is the selected
+    IDs in their original relative order. The selected slides occupy positions
+    ``new_position .. new_position + len(src_ids) - 1`` and the unselected slides
+    keep their relative order around them. Pure function (no COM) so the
+    order-building logic is unit-testable without PowerPoint.
+    """
+    selected = set(src_ids)
+    others = [sid for sid in all_ids if sid not in selected]
+    return others[: new_position - 1] + list(src_ids) + others[new_position - 1:]
+
+
 def _move_slide_impl(
     new_position: int,
     slide_index: Optional[int] = None,
@@ -843,20 +857,12 @@ def _move_slide_impl(
     # Build the FULL desired final order of slide IDs, then realize it. A
     # direction heuristic based on sources[0] is not enough: a non-contiguous
     # selection that straddles the target can leave a member outside the block
-    # (e.g. [1,4,5] -> position 2). Instead, lay out the final order explicitly —
-    # the selected slides (in original order) occupy positions
-    # new_position .. new_position+k-1, and the unselected slides keep their
-    # relative order around them.
-    src_ids = [pres.Slides(i).SlideID for i in sources]
-    selected = set(src_ids)
-    others = [
-        pres.Slides(i).SlideID
-        for i in range(1, total + 1)
-        if pres.Slides(i).SlideID not in selected
-    ]
-    final_ids = (
-        others[: new_position - 1] + src_ids + others[new_position - 1:]
-    )
+    # (e.g. [1,4,5] -> position 2). Instead, lay out the final order explicitly
+    # via _compute_final_order. Read every ID once (total COM calls) and derive
+    # src_ids from that list rather than re-crossing the COM boundary per slide.
+    all_ids = [pres.Slides(i).SlideID for i in range(1, total + 1)]
+    src_ids = [all_ids[i - 1] for i in sources]
+    final_ids = _compute_final_order(all_ids, src_ids, new_position)
 
     # Realize the target order left-to-right. Invariant: once we reach position
     # f, positions 1..f-1 already hold their final slide, so the slide wanted at

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -42,6 +42,7 @@ from ppt_com.slides import (
     DuplicateSlideInput,
     MoveSlideInput,
     CopySlideInput,
+    _compute_final_order,
 )
 from ppt_com.text import (
     GetAllTextInput, SetBulletInput, SetParagraphFormatInput,
@@ -2805,6 +2806,49 @@ class TestMoveSlideInput:
     def test_new_position_required(self):
         with pytest.raises(ValidationError):
             MoveSlideInput(slide_index=2)
+
+
+class TestComputeFinalOrder:
+    """Regression tests for the bulk-move order computation (issue #169).
+
+    Uses 1-based position indices as stand-in slide IDs so the pure ordering
+    logic is exercised without COM. ``sources`` must be passed in original
+    (sorted) order, matching how _move_slide_impl derives src_ids.
+    """
+
+    @staticmethod
+    def _order(sources, total, new_position):
+        all_ids = list(range(1, total + 1))
+        src_ids = [all_ids[i - 1] for i in sources]
+        return _compute_final_order(all_ids, src_ids, new_position)
+
+    def test_noncontiguous_straddling_target(self):
+        # The Codex-reported bug: [1,4,5] -> 2 must yield [B,A,D,E,C] = 2,1,4,5,3.
+        assert self._order([1, 4, 5], 5, 2) == [2, 1, 4, 5, 3]
+
+    def test_contiguous_block_to_front(self):
+        # [4,5] -> 1 yields [E,C,B,A,D]; from A,B,C,D,E that is 4,5,1,2,3.
+        assert self._order([4, 5], 5, 1) == [4, 5, 1, 2, 3]
+
+    def test_single_to_front(self):
+        assert self._order([5], 5, 1) == [5, 1, 2, 3, 4]
+
+    def test_forward_move(self):
+        # Move slide 1 to position 4 in a 5-slide deck.
+        assert self._order([1], 5, 4) == [2, 3, 4, 1, 5]
+
+    def test_noop_position(self):
+        # Moving a contiguous block to where it already is leaves order intact.
+        assert self._order([2, 3], 5, 2) == [1, 2, 3, 4, 5]
+
+    def test_move_to_end(self):
+        assert self._order([1, 2], 5, 4) == [3, 4, 5, 1, 2]
+
+    def test_result_is_permutation(self):
+        result = self._order([1, 3, 5], 6, 2)
+        assert sorted(result) == [1, 2, 3, 4, 5, 6]
+        # Selected slides land contiguously at positions 2,3,4 in original order.
+        assert result[1:4] == [1, 3, 5]
 
 
 class TestCopySlideInput:

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -2827,7 +2827,7 @@ class TestComputeFinalOrder:
         assert self._order([1, 4, 5], 5, 2) == [2, 1, 4, 5, 3]
 
     def test_contiguous_block_to_front(self):
-        # [4,5] -> 1 yields [E,C,B,A,D]; from A,B,C,D,E that is 4,5,1,2,3.
+        # [D,E] -> front of a fresh 5-slide deck gives [D,E,A,B,C] = [4,5,1,2,3].
         assert self._order([4, 5], 5, 1) == [4, 5, 1, 2, 3]
 
     def test_single_to_front(self):

--- a/uv.lock
+++ b/uv.lock
@@ -390,7 +390,7 @@ wheels = [
 
 [[package]]
 name = "ppt-mcp"
-version = "1.4.0"
+version = "1.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },


### PR DESCRIPTION
## Summary

Follow-up fix for a Codex review finding on #170 (bulk slide operations). The bulk-move implementation used a direction heuristic that broke for **non-contiguous selections that straddle the target position**.

### The bug

`_move_slide_impl` chose its iteration order (front-to-back vs back-to-front) from `sources[0]` only. For a non-contiguous selection spanning the target, a member ended up outside the moved block:

```
[1,4,5] -> position 2   gave  [B,A,D,C,E]   (wrong)
                        wanted [B,A,D,E,C]
```

### The fix

Replace the heuristic with an **explicit full-final-order realization**:

1. Compute the complete desired order of slide IDs — selected slides (in original order) at positions `new_position .. new_position+k-1`, unselected slides keeping their relative order around them.
2. Realize it left-to-right. Invariant: once position `f` is reached, positions `1..f-1` already hold their final slide, so the slide wanted at `f` is at some index `>= f`; `MoveTo(f)` shifts only positions `>= f` and never disturbs what is already placed.

SlideID anchoring (`FindBySlideID`) is retained so indices surviving the shifts stay correct.

## Verification

Live-tested against a throwaway 5-slide deck (A–E):

| Case | Result | Expected |
|---|---|---|
| Non-contiguous straddling `[1,4,5] -> 2` | `B,A,D,E,C` | `B,A,D,E,C` ✅ |
| Contiguous `[4,5] -> 1` | `E,C,B,A,D` | `E,C,B,A,D` ✅ |
| Single `[5] -> 1` | `D,E,C,B,A` | `D,E,C,B,A` ✅ (legacy `moved_from`/`moved_to` preserved) |

`uv run pytest` — 560 passed. `uv run python -c "import src.server"` — OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
