### PR TITLE
feat: support mcp 2.x alongside 1.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ppt-mcp"
-version = "1.6.1"
+version = "1.7.0"
 description = "Real-time PowerPoint control via COM automation — an MCP server with 156 tools for AI agents"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -35,9 +35,11 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    # mcp 2.0 renamed mcp.server.fastmcp to mcp.server.mcpserver (FastMCP -> MCPServer)
-    # with no compatibility shim, so the server cannot import under 2.x yet.
-    "mcp[cli]>=1.0.0,<2.0.0",
+    # Both 1.x and 2.x are supported (server.py imports either module layout).
+    # The upper bound is deliberate: mcp 2.0 renamed mcp.server.fastmcp with no
+    # compatibility shim, which broke every install (#176). Keep new majors
+    # opt-in so the same thing cannot happen again.
+    "mcp[cli]>=1.0.0,<3.0.0",
     "pywin32>=306",
     "pydantic>=2.0.0",
 ]

--- a/src/server.py
+++ b/src/server.py
@@ -20,7 +20,14 @@ if _src_dir not in sys.path:
 
 from contextlib import asynccontextmanager
 
-from mcp.server.fastmcp import FastMCP, Image
+# mcp 2.0 renamed mcp.server.fastmcp to mcp.server.mcpserver, and FastMCP to
+# MCPServer, without leaving a compatibility shim behind. Import from whichever
+# module the installed major provides so the server runs on both 1.x and 2.x.
+try:
+    from mcp.server.mcpserver import Image, MCPServer  # mcp >= 2.0
+except ImportError:  # pragma: no cover - depends on the installed mcp major
+    from mcp.server.fastmcp import Image  # mcp 1.x
+    from mcp.server.fastmcp import FastMCP as MCPServer
 
 # Configure logging to stderr (stdout is used for MCP protocol)
 logging.basicConfig(
@@ -32,7 +39,7 @@ logger = logging.getLogger("ppt-mcp")
 
 
 @asynccontextmanager
-async def app_lifespan(server: FastMCP):
+async def app_lifespan(server: MCPServer):
     """Manage COM lifecycle for the MCP server."""
     from utils.com_wrapper import ppt
 
@@ -51,7 +58,7 @@ async def app_lifespan(server: FastMCP):
         ppt.stop()
 
 
-mcp = FastMCP(
+mcp = MCPServer(
     "powerpoint_mcp",
     lifespan=app_lifespan,
     instructions="""

--- a/src/server.py
+++ b/src/server.py
@@ -23,9 +23,14 @@ from contextlib import asynccontextmanager
 # mcp 2.0 renamed mcp.server.fastmcp to mcp.server.mcpserver, and FastMCP to
 # MCPServer, without leaving a compatibility shim behind. Import from whichever
 # module the installed major provides so the server runs on both 1.x and 2.x.
+#
+# Catch ModuleNotFoundError rather than ImportError: the fallback should only
+# trigger when the 2.x module is absent. A broken 2.x install that raises
+# ImportError from one of its own imports must surface that traceback instead
+# of being masked by the 1.x fallback failing afterwards.
 try:
     from mcp.server.mcpserver import Image, MCPServer  # mcp >= 2.0
-except ImportError:  # pragma: no cover - depends on the installed mcp major
+except ModuleNotFoundError:
     from mcp.server.fastmcp import Image  # mcp 1.x
     from mcp.server.fastmcp import FastMCP as MCPServer
 

--- a/tests/test_lazy_connect.py
+++ b/tests/test_lazy_connect.py
@@ -305,7 +305,9 @@ def test_server_lifespan_does_not_eager_connect():
     server_src = (Path(__file__).resolve().parents[1] / "src" / "server.py").read_text(encoding="utf-8")
     # Inside app_lifespan, there must be no ppt.connect()/_connect_impl() call.
     lifespan_start = server_src.index("async def app_lifespan")
-    lifespan_end = server_src.index("mcp = FastMCP(", lifespan_start)
+    # Match the server instantiation without naming the class, which differs
+    # between mcp 1.x (FastMCP) and 2.x (MCPServer).
+    lifespan_end = server_src.index("\nmcp = ", lifespan_start)
     lifespan_block = server_src[lifespan_start:lifespan_end]
     assert "ppt.connect(" not in lifespan_block
     assert "_connect_impl(" not in lifespan_block

--- a/tests/test_server_import.py
+++ b/tests/test_server_import.py
@@ -1,0 +1,59 @@
+"""Import smoke tests for the MCP server entry point.
+
+Every other test module imports individual tool modules but never `server.py`
+itself, so a dependency that renames or drops a symbol `server.py` imports goes
+undetected — mcp 2.0 removing `mcp.server.fastmcp` (issue #176) broke the server
+at module load for every user before any test noticed.
+
+Importing the server does not launch PowerPoint: the COM connection is
+established lazily on the first tool call (issue #148).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+@pytest.fixture(scope="module")
+def server():
+    pytest.importorskip("win32com", reason="pywin32 required to import the server")
+    import src.server as server_module
+
+    return server_module
+
+
+def test_server_module_imports(server):
+    """server.py loads and exposes a server instance and an entry point."""
+    assert server.mcp is not None
+    assert callable(server.main)
+
+
+def test_tools_are_registered(server):
+    """All tools register successfully under whichever mcp major is installed."""
+    tools = asyncio.run(server.mcp.list_tools())
+    assert len(tools) > 100
+    assert all(t.name.startswith("ppt_") for t in tools)
+
+
+def test_annotations_serialize_with_protocol_field_names(server):
+    """Annotations must reach the wire in camelCase, as MCP specifies.
+
+    Tools declare annotations as plain dicts (`{"readOnlyHint": ...}`). Both mcp
+    majors coerce those into a `ToolAnnotations` model whose fields are
+    snake_case, so the protocol names survive only via serialization aliases.
+    """
+    tools = asyncio.run(server.mcp.list_tools())
+    annotated = [t for t in tools if t.annotations is not None]
+    assert annotated, "expected tools to carry annotations"
+
+    dumped = annotated[0].annotations.model_dump(by_alias=True, exclude_none=True)
+    assert "readOnlyHint" in dumped
+    assert "read_only_hint" not in dumped

--- a/uv.lock
+++ b/uv.lock
@@ -390,7 +390,7 @@ wheels = [
 
 [[package]]
 name = "ppt-mcp"
-version = "1.6.1"
+version = "1.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },
@@ -405,7 +405,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mcp", extras = ["cli"], specifier = ">=1.0.0,<2.0.0" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.0.0,<3.0.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pywin32", specifier = ">=306" },
 ]


### PR DESCRIPTION
## Why

#177 caps `mcp[cli]` below 2.0 so the server stops dying at import (#176). That unblocks users but leaves us pinned to a major that will stop getting fixes. This adds real 2.x support and lifts the cap to `<3.0.0`.

> Stacked on #177 — until that merges, this PR's diff also shows its commit.

## What changed

`src/server.py` imports whichever module layout the installed major provides:

```python
try:
    from mcp.server.mcpserver import Image, MCPServer  # mcp >= 2.0
except ImportError:                                    # mcp 1.x
    from mcp.server.fastmcp import Image
    from mcp.server.fastmcp import FastMCP as MCPServer
```

That rename is the entire incompatibility for this codebase:

- Tools are registered via `register_tools(mcp)`, so `mcp.server.fastmcp` was imported in exactly one place.
- `MCPServer.__init__` takes the same `name` / `instructions` / `lifespan` arguments, and `.run()` is unchanged.
- Tool annotations stay plain dicts. Both majors coerce them into `ToolAnnotations` and serialize back to the same camelCase protocol names, so the 156 `annotations={...}` sites need no edits.
- `Image(data=..., format="png")` is re-exported from `mcp.server.mcpserver`.

## Verification

Beyond the suite, I captured the actual `tools/list` response over stdio from a real server process and diffed it three ways — pre-change on 1.x, post-change on 1.x, post-change on 2.x:

| comparison | result |
|---|---|
| pre-change 1.x vs post-change 1.x | identical, all 156 tools |
| pre-change 1.x vs post-change 2.x | identical, all 156 tools |

Identical across `name`, `description`, `inputSchema`, `outputSchema` and `annotations` — including the camelCase `readOnlyHint` family, which is the one thing the `ToolAnnotations` coercion could plausibly have broken.

Test suite: 588 passed on mcp 1.26.0, 588 passed on mcp 2.0.0.

Still unverified: tool *execution* against a live PowerPoint instance under 2.x. The dispatch path is mcp-internal and the schemas are identical, so the risk is low, but the release should be smoke-tested by hand.

## Regression coverage

Adds `tests/test_server_import.py`. No existing test imported `server.py` — every module tests its tools directly — which is exactly why an import-time break reached users unnoticed. It asserts the module loads, tools register, and annotations still serialize with protocol field names.

## Dependency bound

`mcp[cli]>=1.0.0,<3.0.0`. Keeping an upper bound means the next major is an opt-in migration rather than an automatic outage.

Closes #178
