### PR TITLE
ci: run the test suite on push, PR, and before publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,10 +8,18 @@ on:
 
 jobs:
   # ------------------------------------------------------------------ #
+  # Job 0: Gate the release on the same tests PRs run
+  # ------------------------------------------------------------------ #
+  test:
+    name: Tests
+    uses: ./.github/workflows/test.yml
+
+  # ------------------------------------------------------------------ #
   # Job 1: Build the wheel and sdist
   # ------------------------------------------------------------------ #
   build:
     name: Build distribution packages
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,10 @@ on:
   pull_request:
   workflow_call:
 
+# Nothing here needs to write to the repo or read secrets.
+permissions:
+  contents: read
+
 jobs:
   test:
     name: pytest (${{ matrix.label }})
@@ -24,11 +28,21 @@ jobs:
         include:
           # The dependency set users actually get from uv.lock.
           - label: mcp 1.x (locked)
-            major: locked
+            key: locked
+            run: uv run --frozen pytest -q
           # server.py supports both majors (#178). Without this leg, the 2.x
-          # import path would be untested and could rot silently.
+          # import path would be untested and could rot silently — the lockfile
+          # never resolves there. --no-project skips installing the package;
+          # tests/conftest.py puts src/ on sys.path already.
           - label: mcp 2.x
-            major: "2"
+            key: mcp2
+            run: >-
+              uv run --no-project
+              --with "mcp[cli]>=2,<3"
+              --with "pywin32>=306"
+              --with "pydantic>=2"
+              --with pytest
+              python -m pytest -q
 
     env:
       # windows-latest does not default to UTF-8; the suite reads source files
@@ -41,20 +55,13 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
+        with:
+          # Both legs run concurrently and would otherwise race to reserve the
+          # same cache key, leaving one to fail its save step.
+          cache-suffix: ${{ matrix.key }}
 
       - name: Set up Python
         run: uv python install
 
-      - name: Run tests against locked dependencies
-        if: matrix.major == 'locked'
-        run: uv run --frozen pytest -q
-
-      - name: Run tests against mcp 2.x
-        if: matrix.major == '2'
-        run: >
-          uv run --no-project
-          --with "mcp[cli]>=2,<3"
-          --with "pywin32>=306"
-          --with "pydantic>=2"
-          --with pytest
-          python -m pytest -q
+      - name: Run tests
+        run: ${{ matrix.run }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,60 @@
+name: Tests
+
+# Runs on every push and PR, and is called by publish.yml so a release cannot
+# ship without passing the same checks.
+#
+# windows-latest is required: the tests import pywin32, which has no Linux
+# wheel. They do NOT need a live PowerPoint instance — the COM connection is
+# established lazily on the first tool call (#148), so importing the server is
+# safe on a headless runner.
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+  workflow_call:
+
+jobs:
+  test:
+    name: pytest (${{ matrix.label }})
+    runs-on: windows-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # The dependency set users actually get from uv.lock.
+          - label: mcp 1.x (locked)
+            major: locked
+          # server.py supports both majors (#178). Without this leg, the 2.x
+          # import path would be untested and could rot silently.
+          - label: mcp 2.x
+            major: "2"
+
+    env:
+      # windows-latest does not default to UTF-8; the suite reads source files
+      # containing non-ASCII text.
+      PYTHONIOENCODING: utf-8
+      PYTHONUTF8: "1"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python
+        run: uv python install
+
+      - name: Run tests against locked dependencies
+        if: matrix.major == 'locked'
+        run: uv run --frozen pytest -q
+
+      - name: Run tests against mcp 2.x
+        if: matrix.major == '2'
+        run: >
+          uv run --no-project
+          --with "mcp[cli]>=2,<3"
+          --with "pywin32>=306"
+          --with "pydantic>=2"
+          --with pytest
+          python -m pytest -q


### PR DESCRIPTION
## Why

There is no workflow running `pytest`. `publish.yml` goes straight from `uv build` to uploading a wheel, so **nothing verifies a release before it reaches every user**. v1.7.0 was safe only because I ran the suite by hand.

That is also the backdrop to #176: nothing in the suite imported `server.py`, so an import-time break shipped unnoticed. #179 added `tests/test_server_import.py` to cover it, but a test nobody runs automatically is only half a net.

## What changed

- **`test.yml`** — `pytest` on push to `main`/`develop` and on every PR, across both mcp majors.
- **`publish.yml`** — calls `test.yml` via `workflow_call` and gates `build` on it (`needs: test`), so the release path runs exactly the same checks as a PR instead of a second copy that drifts.

`windows-latest` is required: the tests import `pywin32`, which has no Linux wheel. They need no live PowerPoint — the COM connection has been lazy since #148, so importing the server is safe on a headless runner. The repo is public, so Windows runner minutes are free.

The matrix has two legs:

| leg | resolves to | why |
|---|---|---|
| `uv run --frozen pytest` | `uv.lock`, i.e. mcp 1.26.0 | what users actually get |
| `uv run --no-project --with "mcp[cli]>=2,<3" …` | mcp 2.x | the lockfile never resolves here, so the #178 compatibility path would rot silently |

## On the scheduled run I proposed earlier

I initially argued for a cron job resolving dependencies fresh, because #176 broke with **zero commits in this repo** — mcp 2.0.0 shipped and the server died, which no push/PR trigger can ever catch.

That argument stopped applying once #179 bounded the dependency at `<3.0.0`. A new major can no longer enter the resolution silently, so a scheduled job would only guard against a *minor* release breaking imports. That is rare enough not to justify a recurring job that is silent almost always and therefore easy to start ignoring. Dropped it — discussion in #180.

## Verification

Both commands were run locally first: 588 passed against the lockfile, 588 passed against mcp 2.x. Both workflow files parse, and `publish.yml` resolves the `workflow_call` and the `needs: test` edge.

The real check is this PR itself — if `test.yml` is wired correctly, its two legs appear on this PR's checks.

Closes #180
