### PR TITLE
Fix ppt_add_section slide index, inline $defs in tool schemas, accept layout names in ppt_add_slide

### DIFF
--- a/src/ppt_com/sections.py
+++ b/src/ppt_com/sections.py
@@ -53,14 +53,52 @@ def _add_section_impl(name, slide_index):
     pres = ppt._get_pres_impl()
     sp = pres.SectionProperties
 
-    section_index = sp.AddSection(slide_index, name)
+    slide_count = pres.Slides.Count
+    if slide_count == 0:
+        raise ValueError(
+            "The presentation has no slides; add slides before creating sections"
+        )
+    if slide_index > slide_count:
+        raise ValueError(
+            f"slide_index {slide_index} is out of range: "
+            f"the presentation has {slide_count} slide(s)"
+        )
 
-    return {
+    # If a section already starts at this slide, PowerPoint keeps it (now
+    # empty) at its current index and inserts the new section right after it.
+    # Remember it so the caller can be warned.
+    prior = None
+    for i in range(1, sp.Count + 1):
+        if sp.FirstSlide(i) == slide_index:
+            prior = (i, sp.Name(i))
+            break
+
+    # AddSection's first argument is a SECTION index (valid 1..Count+1), so
+    # passing a slide index fails with "Integer out of range" for every
+    # section after the first. AddBeforeSlide takes the slide index and
+    # returns the index of the new section.
+    section_index = sp.AddBeforeSlide(slide_index, name)
+
+    result = {
         "success": True,
         "section_index": section_index,
         "name": name,
         "slide_index": slide_index,
+        "slides_count": sp.SlidesCount(section_index),
+        "sections_count": sp.Count,
     }
+
+    if prior is not None:
+        idx = section_index - 1
+        if not (idx >= 1 and sp.SlidesCount(idx) == 0):
+            idx = prior[0]
+        result["warning"] = (
+            f"Section '{prior[1]}' (index {idx}) also started at slide "
+            f"{slide_index} and is now empty. Delete or move it with "
+            f"ppt_manage_section if that was not intended."
+        )
+
+    return result
 
 
 def _list_sections_impl():
@@ -70,16 +108,22 @@ def _list_sections_impl():
 
     sections = []
     for i in range(1, sp.Count + 1):
+        first = sp.FirstSlide(i)  # -1 for an empty section
+        count = sp.SlidesCount(i)
+        empty = count == 0 or first < 1
         sections.append({
             "index": i,
             "name": sp.Name(i),
-            "first_slide": sp.FirstSlide(i),
-            "slides_count": sp.SlidesCount(i),
+            "first_slide": None if empty else first,
+            "last_slide": None if empty else first + count - 1,
+            "slides_count": count,
+            "empty": empty,
         })
 
     return {
         "success": True,
         "sections_count": sp.Count,
+        "slides_total": pres.Slides.Count,
         "sections": sections,
     }
 
@@ -201,6 +245,8 @@ def register_tools(mcp):
 
         Creates a new section starting at the specified slide.
         Sections group slides for organizational purposes.
+        If a section already starts at that slide, it is left empty and the
+        response carries a warning naming it.
         """
         return add_section(params)
 
@@ -217,7 +263,8 @@ def register_tools(mcp):
     async def tool_list_sections() -> str:
         """List all sections in the active presentation.
 
-        Returns section name, first slide index, and slide count for each section.
+        Returns section name, first/last slide index, slide count and an
+        `empty` flag for each section (empty sections have null slide indices).
         """
         return list_sections()
 

--- a/src/ppt_com/slides.py
+++ b/src/ppt_com/slides.py
@@ -5,7 +5,7 @@ Add, delete, duplicate, move, list, and query slides. Manage speaker notes.
 
 import json
 import logging
-from typing import NamedTuple, Optional
+from typing import NamedTuple, Optional, Union
 
 from pydantic import BaseModel, Field, ConfigDict, model_validator
 
@@ -45,12 +45,13 @@ class AddSlideInput(BaseModel):
             "If omitted, the slide is added at the end."
         ),
     )
-    layout: Optional[int] = Field(
+    layout: Optional[Union[int, str]] = Field(
         default=None,
         description=(
-            "PpSlideLayout constant: 1=Title, 2=Text, 11=TitleOnly, 12=Blank, "
+            "PpSlideLayout constant (1=Title, 2=Text, 11=TitleOnly, 12=Blank, "
             "33=SectionHeader, 34=Comparison, 35=ContentWithCaption, "
-            "36=PictureWithCaption. Ignored if layout_name is provided."
+            "36=PictureWithCaption) or a layout name; a name is treated "
+            "exactly like layout_name. Ignored if layout_name is provided."
         ),
     )
     layout_name: Optional[str] = Field(
@@ -89,6 +90,29 @@ class AddSlideInput(BaseModel):
         description="Number of slides to add. All slides use the same layout. "
         "When count > 1, returns a list of created slide indices.",
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _accept_layout_names_in_layout(cls, data):
+        """Accept a layout name passed via `layout`.
+
+        Callers routinely put a friendly name such as 'blank' into `layout`
+        because the tool text mentions names and integer constants side by
+        side. Rejecting that with an int-parsing error only costs a round
+        trip, so a string is treated like layout_name instead: numeric
+        strings become the integer constant, any other name moves to
+        layout_name (unless layout_name is already set, which wins), and
+        `layout` is cleared.
+        """
+        if isinstance(data, dict) and isinstance(data.get("layout"), str):
+            value = data["layout"].strip()
+            if value.lstrip("+-").isdigit():
+                data["layout"] = int(value)
+            else:
+                if value and not data.get("layout_name"):
+                    data["layout_name"] = value
+                data["layout"] = None
+        return data
 
 
 class DeleteSlideInput(BaseModel):
@@ -1307,9 +1331,10 @@ def register_tools(mcp):
         no layout-name ambiguity (this only copies the look, not the content;
         use ppt_duplicate_slide for a full copy). This is the recommended path.
 
-        Otherwise specify a layout by name (e.g. 'blank', 'title', 'title_only')
-        or by PpSlideLayout integer constant. You can also provide a custom
-        layout_name to match a layout from the slide master.
+        Otherwise pass layout_name (a friendly name such as 'blank', 'title',
+        'title_only', or a custom layout name from the slide master) or layout
+        (a PpSlideLayout integer constant; a name passed here is treated like
+        layout_name).
         Position is 1-based; omit to append at the end.
         Use design_index to pick a layout from a specific slide master/design.
         Use count to create multiple slides at once; when count > 1, returns

--- a/src/ppt_com/slides.py
+++ b/src/ppt_com/slides.py
@@ -103,13 +103,22 @@ class AddSlideInput(BaseModel):
         strings become the integer constant, any other name moves to
         layout_name (unless layout_name is already set, which wins), and
         `layout` is cleared.
+
+        An empty or blank string is rejected rather than treated as "no
+        layout": it almost always means a template variable was never filled
+        in, and silently producing a blank slide hides that from the caller.
         """
         if isinstance(data, dict) and isinstance(data.get("layout"), str):
             value = data["layout"].strip()
+            if not value:
+                raise ValueError(
+                    "layout is empty. Omit it to use the default layout, or "
+                    "pass a PpSlideLayout constant or a layout name."
+                )
             if value.lstrip("+-").isdigit():
                 data["layout"] = int(value)
             else:
-                if value and not data.get("layout_name"):
+                if not data.get("layout_name"):
                     data["layout_name"] = value
                 data["layout"] = None
         return data

--- a/src/server.py
+++ b/src/server.py
@@ -3,6 +3,7 @@
 Real-time PowerPoint control via COM automation.
 """
 
+import json
 import logging
 import os
 import sys
@@ -471,6 +472,63 @@ async def tool_ppt_get_slide_preview(params: GetSlidePreviewInput) -> Image:
 
     image_data = ppt.execute(_export_slide_impl, params.slide_index)
     return Image(data=image_data, format="png")
+
+
+# =============================================================================
+# Tool schema post-processing
+# =============================================================================
+
+
+def _inline_schema_defs(server) -> int:
+    """Inline ``$defs`` references in every registered tool's input schema.
+
+    Every tool takes a single Pydantic model (``params: XInput``), and the SDK
+    renders that as ``{"params": {"$ref": "#/$defs/XInput"}}`` with the model's
+    fields tucked away under ``$defs``. MCP clients such as Claude Desktop do
+    not dereference ``$ref``, so ``params`` showed up as an empty object and
+    callers had to guess field names from validation errors. Inlining keeps
+    the wire schema self-contained; validation still runs against the Pydantic
+    model and is unaffected.
+
+    Returns the number of tools whose schema was rewritten.
+    """
+
+    def _resolve(node, defs, stack):
+        if isinstance(node, list):
+            return [_resolve(item, defs, stack) for item in node]
+        if not isinstance(node, dict):
+            return node
+        ref = node.get("$ref")
+        if isinstance(ref, str) and ref.startswith("#/$defs/"):
+            name = ref[len("#/$defs/"):]
+            target = defs.get(name)
+            if target is not None and name not in stack:
+                merged = dict(target)
+                # Keep sibling keys (e.g. a field-level description) next to
+                # the inlined definition.
+                merged.update({k: v for k, v in node.items() if k != "$ref"})
+                return _resolve(merged, defs, stack + [name])
+            # Unknown target or a recursive schema: leave the reference alone.
+        return {key: _resolve(value, defs, stack) for key, value in node.items()}
+
+    rewritten = 0
+    for tool in server._tool_manager.list_tools():
+        schema = tool.parameters
+        if not isinstance(schema, dict) or "$defs" not in schema:
+            continue
+        defs = schema["$defs"]
+        inlined = _resolve({k: v for k, v in schema.items() if k != "$defs"}, defs, [])
+        if "$ref" in json.dumps(inlined):
+            # Something could not be resolved (recursive model); keep $defs so
+            # the remaining references stay valid.
+            inlined["$defs"] = defs
+        tool.parameters = inlined
+        rewritten += 1
+    return rewritten
+
+
+_inlined_tool_count = _inline_schema_defs(mcp)
+logger.debug("Inlined $defs in %d tool schemas", _inlined_tool_count)
 
 
 def main():

--- a/src/server.py
+++ b/src/server.py
@@ -527,8 +527,19 @@ def _inline_schema_defs(server) -> int:
     return rewritten
 
 
-_inlined_tool_count = _inline_schema_defs(mcp)
-logger.debug("Inlined $defs in %d tool schemas", _inlined_tool_count)
+try:
+    _inlined_tool_count = _inline_schema_defs(mcp)
+    logger.debug("Inlined $defs in %d tool schemas", _inlined_tool_count)
+except Exception:
+    # _tool_manager and Tool.parameters are SDK internals, and the SDK has
+    # renamed internals across majors before (see the MCPServer import above).
+    # Losing the inlining costs clients an extra round trip; losing the import
+    # would cost them every tool, so degrade instead of failing to start.
+    logger.warning(
+        "Could not inline $defs in tool schemas; they keep their $ref form",
+        exc_info=True,
+    )
+    _inlined_tool_count = 0
 
 
 def main():

--- a/tests/test_sections.py
+++ b/tests/test_sections.py
@@ -1,0 +1,208 @@
+"""Tests for the section tools (ppt_add_section / ppt_list_sections).
+
+Pure Python tests -- a fake COM SectionProperties object mimics PowerPoint's
+behaviour so the slide-index handling can be verified without PowerPoint.
+
+Background: SectionProperties.AddSection takes a SECTION index as its first
+argument (valid 1..Count+1). Passing the slide index there only works for the
+very first section; every later one fails with "Integer out of range". The
+implementation must use AddBeforeSlide, which takes the slide index.
+"""
+
+import sys
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, "src")
+
+from ppt_com import sections  # noqa: E402
+
+
+# --- Fake COM object graph -------------------------------------------------
+
+class _FakeSlides:
+    def __init__(self, count):
+        self.Count = count
+
+
+class _FakeSectionProperties:
+    """Mimics PowerPoint's SectionProperties for a fixed number of slides.
+
+    Sections are stored as [name, first_slide]; an empty section has
+    first_slide -1, exactly like PowerPoint reports it.
+    """
+
+    def __init__(self, slide_count, sections=None):
+        self._slide_count = slide_count
+        # list of [name, first_slide]
+        self._sections = [list(s) for s in (sections or [])]
+        self.add_section_calls = []
+        self.add_before_slide_calls = []
+
+    # -- read side -----------------------------------------------------------
+    @property
+    def Count(self):
+        return len(self._sections)
+
+    def Name(self, i):
+        return self._sections[i - 1][0]
+
+    def FirstSlide(self, i):
+        return self._sections[i - 1][1]
+
+    def SlidesCount(self, i):
+        first = self._sections[i - 1][1]
+        if first < 1:
+            return 0
+        later = [s[1] for s in self._sections[i:] if s[1] >= 1]
+        end = min(later) - 1 if later else self._slide_count
+        return end - first + 1
+
+    # -- write side ----------------------------------------------------------
+    def AddSection(self, section_index, name):
+        self.add_section_calls.append((section_index, name))
+        if not 1 <= section_index <= self.Count + 1:
+            raise Exception(
+                "SectionProperties.AddSection : Integer out of range. "
+                f"{section_index} is not in sectionIndex's valid range of "
+                f"1 to {self.Count + 1}."
+            )
+        self._sections.insert(section_index - 1, [name, -1])
+        return section_index
+
+    def AddBeforeSlide(self, slide_index, name):
+        self.add_before_slide_calls.append((slide_index, name))
+        if not 1 <= slide_index <= self._slide_count:
+            raise Exception(
+                "SectionProperties.AddBeforeSlide : Integer out of range. "
+                f"{slide_index} is not in SlideIndex's valid range of "
+                f"1 to {self._slide_count}."
+            )
+        # A section already starting here is kept (now empty) at its index;
+        # the new section goes right after it.
+        for pos, sec in enumerate(self._sections):
+            if sec[1] == slide_index:
+                sec[1] = -1
+                self._sections.insert(pos + 1, [name, slide_index])
+                return pos + 2
+        # Otherwise insert after the last section that starts before this
+        # slide (that section is split).
+        pos = 0
+        for idx, sec in enumerate(self._sections):
+            if 1 <= sec[1] < slide_index:
+                pos = idx + 1
+        self._sections.insert(pos, [name, slide_index])
+        return pos + 1
+
+
+class _FakePres:
+    def __init__(self, slide_count, sections=None):
+        self.Slides = _FakeSlides(slide_count)
+        self.SectionProperties = _FakeSectionProperties(slide_count, sections)
+
+
+def _with_pres(pres):
+    """Route the module's COM accessors to the fake presentation."""
+    return (
+        patch.object(sections.ppt, "_get_app_impl", return_value=object()),
+        patch.object(sections.ppt, "_get_pres_impl", return_value=pres),
+    )
+
+
+def _ranges(listing):
+    return [(s["first_slide"], s["last_slide"]) for s in listing["sections"]]
+
+
+# --- _add_section_impl -----------------------------------------------------
+
+def test_add_three_sections_uses_add_before_slide():
+    pres = _FakePres(slide_count=6)
+    sp = pres.SectionProperties
+    p_app, p_pres = _with_pres(pres)
+    with p_app, p_pres:
+        r1 = sections._add_section_impl("Intro", 1)
+        r2 = sections._add_section_impl("Body", 3)
+        r3 = sections._add_section_impl("Close", 5)
+        listing = sections._list_sections_impl()
+
+    assert (r1["section_index"], r2["section_index"], r3["section_index"]) == (1, 2, 3)
+    assert all(r["success"] for r in (r1, r2, r3))
+    assert "warning" not in r2 and "warning" not in r3
+    assert sp.add_before_slide_calls == [(1, "Intro"), (3, "Body"), (5, "Close")]
+    assert sp.add_section_calls == []
+    assert _ranges(listing) == [(1, 2), (3, 4), (5, 6)]
+    assert r3["slides_count"] == 2
+    assert r3["sections_count"] == 3
+
+
+def test_add_section_slide_index_out_of_range_is_clear_error():
+    pres = _FakePres(slide_count=6, sections=[("Intro", 1)])
+    p_app, p_pres = _with_pres(pres)
+    with p_app, p_pres, pytest.raises(ValueError) as exc:
+        sections._add_section_impl("Too far", 7)
+    msg = str(exc.value)
+    assert "out of range" in msg
+    assert "6 slide" in msg
+    assert pres.SectionProperties.add_before_slide_calls == []
+
+
+def test_add_section_without_slides_is_clear_error():
+    pres = _FakePres(slide_count=0)
+    p_app, p_pres = _with_pres(pres)
+    with p_app, p_pres, pytest.raises(ValueError) as exc:
+        sections._add_section_impl("Intro", 1)
+    assert "no slides" in str(exc.value)
+
+
+def test_add_section_at_existing_start_warns_about_emptied_section():
+    pres = _FakePres(slide_count=6, sections=[("Intro", 1), ("Body", 3), ("Close", 5)])
+    p_app, p_pres = _with_pres(pres)
+    with p_app, p_pres:
+        result = sections._add_section_impl("Twice", 3)
+        listing = sections._list_sections_impl()
+
+    assert result["success"] is True
+    assert result["section_index"] == 3
+    assert "Body" in result["warning"]
+    assert "index 2" in result["warning"]
+    assert [s["name"] for s in listing["sections"]] == ["Intro", "Body", "Twice", "Close"]
+    assert listing["sections"][1]["empty"] is True
+
+
+# --- _list_sections_impl ---------------------------------------------------
+
+def test_list_sections_reports_empty_section_and_last_slide():
+    pres = _FakePres(slide_count=6, sections=[("Intro", 1), ("Gone", -1), ("Rest", 3)])
+    p_app, p_pres = _with_pres(pres)
+    with p_app, p_pres:
+        listing = sections._list_sections_impl()
+
+    assert listing["success"] is True
+    assert listing["sections_count"] == 3
+    assert listing["slides_total"] == 6
+
+    intro, gone, rest = listing["sections"]
+    assert (intro["first_slide"], intro["last_slide"], intro["slides_count"]) == (1, 2, 2)
+    assert intro["empty"] is False
+
+    assert gone["first_slide"] is None
+    assert gone["last_slide"] is None
+    assert gone["slides_count"] == 0
+    assert gone["empty"] is True
+
+    assert (rest["first_slide"], rest["last_slide"]) == (3, 6)
+    assert rest["last_slide"] == rest["first_slide"] + rest["slides_count"] - 1
+
+
+def test_list_sections_empty_presentation():
+    pres = _FakePres(slide_count=0)
+    p_app, p_pres = _with_pres(pres)
+    with p_app, p_pres:
+        listing = sections._list_sections_impl()
+    assert listing == {
+        "success": True,
+        "sections_count": 0,
+        "slides_total": 0,
+        "sections": [],
+    }

--- a/tests/test_server_import.py
+++ b/tests/test_server_import.py
@@ -12,6 +12,7 @@ established lazily on the first tool call (issue #148).
 from __future__ import annotations
 
 import asyncio
+import json
 import sys
 from pathlib import Path
 
@@ -57,3 +58,44 @@ def test_annotations_serialize_with_protocol_field_names(server):
     dumped = annotated[0].annotations.model_dump(by_alias=True, exclude_none=True)
     assert "readOnlyHint" in dumped
     assert "read_only_hint" not in dumped
+
+
+def _input_schema(tool) -> dict:
+    """Wire schema of a tool under either mcp major (`input_schema` / `inputSchema`)."""
+    schema = getattr(tool, "input_schema", None)
+    if schema is None:
+        schema = getattr(tool, "inputSchema", None)
+    return schema or {}
+
+
+def test_tool_schemas_are_self_contained(server):
+    """Wire schemas carry no `$ref`/`$defs`; nested `params` models are inlined.
+
+    Clients such as Claude Desktop do not dereference `$ref`, so a tool whose
+    `params` model was only referenced showed up with an empty `params` object
+    and callers had to guess the field names from validation errors.
+    """
+    tools = asyncio.run(server.mcp.list_tools())
+    schemas = {t.name: _input_schema(t) for t in tools}
+
+    with_refs = sorted(
+        name for name, schema in schemas.items()
+        if "$ref" in json.dumps(schema) or "$defs" in schema
+    )
+    assert with_refs == [], f"unresolved $ref/$defs in: {with_refs[:10]}"
+
+    # Every `params` must be an inlined object schema with its fields visible.
+    # (A model without fields legitimately inlines to `"properties": {}`.)
+    opaque_params = sorted(
+        name for name, schema in schemas.items()
+        if "params" in schema.get("properties", {})
+        and (
+            schema["properties"]["params"].get("type") != "object"
+            or "properties" not in schema["properties"]["params"]
+        )
+    )
+    assert opaque_params == [], f"params not inlined in: {opaque_params[:10]}"
+
+    params = schemas["ppt_add_section"]["properties"]["params"]
+    assert params["properties"]["slide_index"]["minimum"] == 1
+    assert "slide_index" in params["required"]

--- a/tests/test_slides_layout.py
+++ b/tests/test_slides_layout.py
@@ -71,6 +71,46 @@ def test_like_slide_index_zero_accepted_by_model():
     assert m.like_slide_index == 0
 
 
+# --- layout accepts names as well as PpSlideLayout constants ---------------
+
+def test_layout_name_string_moves_to_layout_name():
+    # Callers put friendly names into `layout`; treat that like layout_name
+    # instead of failing validation with int_parsing.
+    m = AddSlideInput(layout="blank")
+    assert m.layout is None
+    assert m.layout_name == "blank"
+
+
+def test_layout_numeric_string_becomes_int():
+    m = AddSlideInput(layout="12")
+    assert m.layout == 12
+    assert m.layout_name is None
+
+
+def test_layout_name_field_wins_over_layout_string():
+    m = AddSlideInput(layout="blank", layout_name="Titelfolie")
+    assert m.layout_name == "Titelfolie"
+    assert m.layout is None
+
+
+def test_layout_int_unchanged():
+    m = AddSlideInput(layout=12)
+    assert m.layout == 12
+    assert m.layout_name is None
+
+
+def test_layout_empty_string_becomes_none():
+    m = AddSlideInput(layout="")
+    assert m.layout is None
+    assert m.layout_name is None
+
+
+def test_layout_schema_accepts_integer_and_string():
+    layout_schema = AddSlideInput.model_json_schema()["properties"]["layout"]
+    types = {arm.get("type") for arm in layout_schema["anyOf"]}
+    assert {"integer", "string"} <= types
+
+
 # --- _find_layout_matches --------------------------------------------------
 
 def _pres():

--- a/tests/test_slides_layout.py
+++ b/tests/test_slides_layout.py
@@ -7,6 +7,9 @@ PowerPoint.
 
 import sys
 
+import pytest
+from pydantic import ValidationError
+
 sys.path.insert(0, "src")
 
 from ppt_com.slides import AddSlideInput, _find_layout_matches
@@ -99,10 +102,12 @@ def test_layout_int_unchanged():
     assert m.layout_name is None
 
 
-def test_layout_empty_string_becomes_none():
-    m = AddSlideInput(layout="")
-    assert m.layout is None
-    assert m.layout_name is None
+def test_layout_empty_string_is_rejected():
+    """An empty layout usually means an unfilled template variable. Saying so
+    beats silently handing back a blank slide."""
+    for blank in ("", "   ", "\t"):
+        with pytest.raises(ValidationError, match="layout is empty"):
+            AddSlideInput(layout=blank)
 
 
 def test_layout_schema_accepts_integer_and_string():


### PR DESCRIPTION
## Summary

Three independent fixes, all found in real sessions with Claude driving the
server. Each one either made a feature unusable or cost a failed round trip on
the first use of a tool: `ppt_add_section` could only ever create the first
section of a deck, the served input schemas hid every field behind an
unresolved `$ref`, and `ppt_add_slide` rejected layout names passed via
`layout` although the tool text invites exactly that. One commit per fix; they
are independent and can be reviewed one by one.

## 1. `ppt_add_section`: slide index passed to `AddSection`

**Problem.** `_add_section_impl` calls
`SectionProperties.AddSection(slide_index, name)`. The first parameter of that
COM method is the **section** index (valid range `1..Count+1`), not a slide
index. Consequently only the very first section can be created; any further
section whose slide index exceeds `sections + 1` fails with

```
SectionProperties.AddSection : Integer out of range. 3 is not in sectionIndex's valid range of 1 to 2.
```

Reproduction: new 16:9 deck, 6 slides,
`ppt_add_section(name="Intro", slide_index=1)` succeeds,
`ppt_add_section(name="Main", slide_index=3)` fails with the error above.

**Root cause.** A mix-up of the two COM methods.
`AddBeforeSlide(SlideIndex, sectionName)` is the one that takes a slide index;
it inserts the new section before that slide and returns the new section's
index.

**Fix.**

- Use `SectionProperties.AddBeforeSlide(slide_index, name)`.
- Validate `slide_index` against `Presentation.Slides.Count` and return a clear
  error, e.g. `slide_index 7 is out of range: the presentation has 6 slide(s)`;
  a deck without slides is rejected the same way.
- When a section already starts at that slide, PowerPoint leaves the old
  section empty and inserts the new one right after it. The response now
  carries a `warning` naming the emptied section and its index so callers can
  delete or move it.
- The `ppt_add_section` response additionally returns `slides_count` (of the
  new section) and `sections_count`.

**`ppt_list_sections`.** `FirstSlide` returns `-1` for an empty section and
was passed through verbatim. Empty sections are now reported with
`empty: true` and `first_slide` / `last_slide` = `null`. New fields:
`last_slide` per section and `slides_total` at the top level.

**Tests.** New `tests/test_sections.py` with a fake COM object graph (same
approach as `tests/test_slides_layout.py`): three sections at slides 1/3/5, no
`AddSection` call, out-of-range and no-slides errors, the warning for a
duplicate section start, and empty-section listing.

## 2. Tool schemas: inline `$defs`

**Problem.** Every tool takes a single Pydantic model (`params: XInput`). The
SDK renders that input schema as
`{"properties": {"params": {"$ref": "#/$defs/XInput"}}, "$defs": {...}}` —
144 of the 156 tools look like this. Clients that do not dereference `$ref`
(observed: Claude Desktop) show `params` as an empty object, so the model has
to guess field names from validation errors. Example: `ppt_add_section` called
with `before_slide_index` → `params.slide_index Field required`.

**Fix.** `_inline_schema_defs(mcp)` in `src/server.py`, called once at module
level after all registrations. It resolves `#/$defs/...` references
recursively — sibling keys such as a field-level description are kept,
recursive schemas are left untouched and keep their `$defs` — and assigns the
self-contained schema to `tool.parameters`. Validation is unaffected: it still
runs against the Pydantic model. Works with mcp 1.x and 2.x (`_tool_manager`
and `Tool.parameters` are the same in both).

**Test.** `test_tool_schemas_are_self_contained` in
`tests/test_server_import.py`: no `$ref`/`$defs` in any served schema, every
`params` is an inlined object schema, `ppt_add_section` exposes `slide_index`
(minimum 1, required). Two tools (`ppt_get_theme_colors`,
`ppt_get_slide_size`) have field-less input models and legitimately inline to
`"properties": {}`.

## 3. `ppt_add_slide`: accept layout names in `layout`

**Problem.** `layout` is `Optional[int]`, while the tool text says "specify a
layout by name (e.g. 'blank', 'title', 'title_only') or by PpSlideLayout
integer constant" without naming the field. Callers put `"blank"` into
`layout` and get
`Input should be a valid integer, unable to parse string as an integer`.

**Fix.** `layout: Optional[Union[int, str]]` plus a
`model_validator(mode="before")`: a numeric string becomes the integer
constant, any other name is moved into `layout_name` (an explicitly given
`layout_name` wins), and `layout` is cleared. The field description and the
tool docstring now name `layout_name` as the field for names.
`_add_slide_impl` is unchanged — it already takes the `layout_name` path.

**Tests.** Six new model tests in `tests/test_slides_layout.py`: name string,
numeric string, precedence of `layout_name`, plain int unchanged, empty
string, and the JSON schema offering both integer and string.

## Testing

- Unit tests: `tests/test_sections.py`, `test_tool_schemas_are_self_contained`
  and the six `AddSlideInput` model tests. Full `pytest tests` green on Windows
  with mcp 2.0.0 (601 passed); no PowerPoint is needed for these tests.
- Verified live through the MCP server against Microsoft 365 PowerPoint
  (German locale): sections create / list / rename / move / delete plus the
  edge cases above — the section at slide 3 that used to fail now succeeds;
  tools/list carries `params.properties` for all 144 wrapper tools.

## Notes for reviewers

All wire changes are additive: the only value that differs from before is
`first_slide` `-1` → `null` for empty sections; schemas gain their inlined
fields; `layout` additionally accepts strings. `ppt_manage_section` (rename /
move / delete) was unaffected and is unchanged. The commits are independent
and can be reviewed one by one.
