### PR TITLE
fix: recover from a COM worker stuck inside a PowerPoint call

### DIFF
--- a/src/utils/com_wrapper.py
+++ b/src/utils/com_wrapper.py
@@ -16,7 +16,7 @@ from concurrent.futures import (
     TimeoutError as FuturesTimeoutError,
 )
 from contextvars import ContextVar
-from queue import Queue
+from queue import Empty, Queue
 from typing import Any, Callable, Optional
 
 import pythoncom
@@ -88,9 +88,14 @@ _BUSY_BACKOFF = (0.5, 1.0, 2.0, 3.0)
 _CALL_TIMEOUT = 30.0
 # Shown whenever the wait budget runs out, wherever in the wait it happens.
 _BUSY_TIMEOUT_MESSAGE = (
-    "PowerPoint did not respond within %.0fs -- a dialog or menu is probably "
+    "PowerPoint did not respond within %.0fs. A dialog or menu is probably "
     "open. Close it and retry." % _BUSY_WAIT_BUDGET
 )
+# How long execute() gives a replacement worker to prove that PowerPoint
+# answers again before it reports the connection as still being rebuilt.
+# Short on purpose: a recovery that goes well should be invisible, and one
+# that does not should not cost every later call another full timeout.
+_HEALTH_WAIT = 2.0
 # When True, the server sends ESC to PowerPoint on the first busy rejection to
 # dismiss any blocking modal dialog automatically.
 # Opt-in: set PPT_AUTO_DISMISS_DIALOG=true in mcp.json env to enable:
@@ -165,17 +170,35 @@ class PowerPointCOMWrapper:
         self._queue: Queue = Queue()
         self._running = False
         self._target_pres_full_name: Optional[str] = None  # session-level target (FullName for uniqueness)
+        # Which worker generation is the live one.  A worker abandoned after a
+        # wedge keeps its own generation, sees that it is no longer current,
+        # and stops touching shared state (issue #199).
+        self._generation = 0
+        # Clear while a replacement worker is still proving that PowerPoint
+        # answers.  execute() then fails fast instead of queueing behind a
+        # connection that may not be there.
+        self._healthy = threading.Event()
+        self._healthy.set()
+        self._recover_lock = threading.Lock()
 
     def start(self) -> None:
         """Start the COM worker thread."""
         if self._running:
             return
         self._running = True
+        self._healthy.set()
+        self._start_worker(self._queue, self._generation)
+        logger.info("COM worker thread started")
+
+    def _start_worker(self, queue: Queue, generation: int) -> None:
+        """Spawn a worker bound to one queue and one generation."""
         self._com_thread = threading.Thread(
-            target=self._com_worker, daemon=True, name="COM-Worker"
+            target=self._com_worker,
+            args=(queue, generation),
+            daemon=True,
+            name="COM-Worker-%d" % generation,
         )
         self._com_thread.start()
-        logger.info("COM worker thread started")
 
     def stop(self) -> None:
         """Stop the COM worker thread and clean up."""
@@ -334,15 +357,121 @@ class PowerPointCOMWrapper:
             time.sleep(min(delay, remaining))
             attempt += 1
 
-    def _com_worker(self) -> None:
-        """Worker thread that processes COM operations in an STA apartment."""
+    def _recover_from_wedge(self, generation: int) -> bool:
+        """Abandon a worker stuck inside a COM call and start a fresh one.
+
+        An outgoing COM call cannot be cancelled from this side, so the stuck
+        thread cannot be reclaimed.  It is a daemon thread and is left to
+        finish or not.  What recovery buys is that the next operation meets a
+        working worker instead of queueing behind the stuck one forever, which
+        previously needed a client restart (issue #199).
+
+        Args:
+            generation: the worker generation the timed-out call belonged to.
+                Recovery is skipped if that generation has already been
+                replaced, so several callers timing out together still
+                produce one replacement.
+
+        Returns:
+            True if this call performed the recovery.
+        """
+        with self._recover_lock:
+            if generation != self._generation or not self._running:
+                return False
+            old_queue = self._queue
+            self._generation = generation + 1
+            self._healthy.clear()
+            self._queue = Queue()
+            logger.error(
+                "The COM worker is stuck inside a PowerPoint call. Abandoning "
+                "it and starting worker generation %d.", self._generation,
+            )
+            self._start_worker(self._queue, self._generation)
+
+        # Outside the lock.  Everything the abandoned worker had not started
+        # is dropped rather than applied once it unwedges, long after the
+        # callers were told their operations had failed.
+        while True:
+            try:
+                item = old_queue.get_nowait()
+            except Empty:
+                break
+            if item is not None:
+                item[3].cancel()
+        # If the abandoned worker ever does return from its call it goes back
+        # to get().  The sentinel stops it blocking there for good.
+        old_queue.put(None)
+        return True
+
+    def _reattach_after_wedge(self, generation: int) -> None:
+        """Prove PowerPoint answers again before letting traffic resume.
+
+        A replacement worker runs in a fresh apartment, so the proxy the
+        wedged worker held is useless here and is dropped.  Connecting proper
+        is still _connect_impl's job; all this does is find out whether
+        PowerPoint is answering at all.
+
+        Staying unhealthy is the point.  A busy rejection most likely means
+        the modal dialog that caused the wedge is still up, and reporting
+        health then would turn the next call into a misleading "partially
+        applied" error for an operation that never started.  Any other failure
+        is reported as healthy so that _connect_impl can relaunch PowerPoint
+        the way it always has.
+        """
+        self._app = None
+        attempt = 0
+        while self._running and generation == self._generation:
+            try:
+                app = win32com.client.GetActiveObject("PowerPoint.Application")
+                _ = app.Name
+                self._app = app
+                logger.info("Reattached to PowerPoint after a wedged call")
+                break
+            except pywintypes.com_error as e:
+                if e.hresult not in _BUSY_HRESULTS:
+                    logger.warning(
+                        "Could not reattach to PowerPoint after the wedge "
+                        "(%s). The next operation will connect normally.", e,
+                    )
+                    break
+                delay = _BUSY_BACKOFF[min(attempt, len(_BUSY_BACKOFF) - 1)]
+                logger.warning(
+                    "PowerPoint is still busy after the wedge, probing again "
+                    "in %.1fs", delay,
+                )
+                time.sleep(delay)
+                attempt += 1
+            except Exception as e:
+                logger.warning(
+                    "Could not reattach to PowerPoint after the wedge (%s). "
+                    "The next operation will connect normally.", e,
+                )
+                break
+
+        if generation == self._generation:
+            self._healthy.set()
+
+    def _com_worker(self, queue: Queue, generation: int) -> None:
+        """Worker thread that processes COM operations in an STA apartment.
+
+        Each worker owns the queue it was started with rather than reading
+        self._queue, so a worker abandoned after a wedge cannot drain the
+        queue its replacement is serving (issue #199).
+        """
         pythoncom.CoInitializeEx(pythoncom.COINIT_APARTMENTTHREADED)
         try:
-            while self._running:
-                item = self._queue.get()
+            if generation > 0:
+                self._reattach_after_wedge(generation)
+            while self._running and generation == self._generation:
+                item = queue.get()
                 if item is None:
                     break
                 func, args, kwargs, future, idempotent = item
+                if generation != self._generation:
+                    # Abandoned while this item sat in the queue, so it
+                    # arrived after _recover_from_wedge had drained it.
+                    future.cancel()
+                    break
                 try:
                     self._run_item(func, args, kwargs, future, idempotent)
                 except BaseException:
@@ -355,7 +484,10 @@ class PowerPointCOMWrapper:
                             RuntimeError("The COM worker failed unexpectedly.")
                         )
         finally:
-            self._cleanup_com()
+            # An abandoned worker shares self._app with the live one and must
+            # not clear it on the way out.
+            if generation == self._generation:
+                self._cleanup_com()
             pythoncom.CoUninitialize()
 
     def execute(self, func: Callable, *args: Any,
@@ -379,10 +511,20 @@ class PowerPointCOMWrapper:
             The return value of func
 
         Raises:
-            RuntimeError: if the COM worker thread has died, or if the wait
-                times out.
+            RuntimeError: if the COM worker thread has died, if a previous
+                call wedged it and the replacement has not reconnected yet,
+                or if the wait times out.
             Any exception raised by func
         """
+        if not self._healthy.wait(_HEALTH_WAIT):
+            # A replacement worker is still probing.  Queueing here would
+            # cost another full timeout to learn what is already known
+            # (issue #199).
+            raise RuntimeError(
+                "PowerPoint stopped responding and the connection is being "
+                "rebuilt. Close any dialog open in PowerPoint, then retry."
+            )
+
         if self._com_thread is not None and not self._com_thread.is_alive():
             # Nothing is draining the queue any more, so queueing would just
             # burn the full timeout before failing (issue #199).
@@ -391,8 +533,12 @@ class PowerPointCOMWrapper:
                 "Restart the MCP server to reconnect to PowerPoint."
             )
 
+        # Read both once: recovery swaps the queue and bumps the generation,
+        # and this call has to be attributed to the one it was queued on.
+        generation = self._generation
+        queue = self._queue
         future: Future = Future()
-        self._queue.put((func, args, kwargs, future, idempotent))
+        queue.put((func, args, kwargs, future, idempotent))
         watching = pending_com_futures.get()
         if watching is not None:
             watching.add(future)
@@ -422,17 +568,30 @@ class PowerPointCOMWrapper:
             # outgoing calls are not interruptible -- but everything queued
             # behind it is dropped rather than applied after the fact.
             cancelled = future.cancel()
-            if not cancelled and future.done():
+            if cancelled:
+                raise RuntimeError(
+                    "PowerPoint did not finish the operation within %.0fs "
+                    "and it was cancelled."
+                    % (_BUSY_WAIT_BUDGET + _CALL_TIMEOUT)
+                ) from None
+            if future.done():
                 # It finished in the moment between the timeout and the
                 # cancel; the caller may as well have the outcome.
                 return future.result()
+
+            # The future could be neither cancelled nor read, so the worker is
+            # inside the call and has been for the whole timeout.  That is the
+            # wedge, and only the call it is stuck on can tell.  Callers
+            # queued behind it cancel cleanly and must not trigger a second
+            # replacement.
+            recovered = self._recover_from_wedge(generation)
             raise RuntimeError(
-                "PowerPoint did not finish the operation within "
-                "%.0fs and it was %s."
+                "PowerPoint did not finish the operation within %.0fs and it "
+                "was left running, so it may still be applied.%s"
                 % (
                     _BUSY_WAIT_BUDGET + _CALL_TIMEOUT,
-                    "cancelled" if cancelled
-                    else "left running -- it may still be applied",
+                    " A fresh connection is being established."
+                    if recovered else "",
                 )
             ) from None
 

--- a/src/utils/com_wrapper.py
+++ b/src/utils/com_wrapper.py
@@ -205,9 +205,18 @@ class PowerPointCOMWrapper:
         """Start the COM worker thread."""
         if self._running:
             return
-        self._running = True
-        self._healthy.set()
-        self._start_worker(self._queue, self._generation)
+        with self._recover_lock:
+            self._running = True
+            # A deliberate restart is a fresh start, not a continuation of the
+            # last wedge.  Generation 0 skips the reattach probe, so a restart
+            # that happens to catch PowerPoint busy behaves like a normal
+            # start rather than inheriting the unbounded wait meant for
+            # recovery.  A new queue cannot hand the worker a stop sentinel
+            # left over from the previous shutdown either.
+            self._generation = 0
+            self._queue = Queue()
+            self._healthy.set()
+            self._start_worker(self._queue, self._generation)
         logger.info("COM worker thread started")
 
     def _start_worker(self, queue: Queue, generation: int) -> None:
@@ -224,11 +233,19 @@ class PowerPointCOMWrapper:
         """Stop the COM worker thread and clean up."""
         if not self._running:
             return
-        self._running = False
-        # Send a sentinel to unblock the worker
-        self._queue.put(None)
-        if self._com_thread and self._com_thread.is_alive():
-            self._com_thread.join(timeout=5.0)
+        # Under the recovery lock, and read once.  A wedge confirmed at this
+        # exact moment would otherwise swap the queue and the thread in
+        # between, leaving the sentinel on the abandoned queue and the live
+        # worker running while stop() reported success.  Clearing _running
+        # here also stops any recovery that has not started yet, since
+        # _recover_from_wedge checks it under this same lock.
+        with self._recover_lock:
+            self._running = False
+            queue = self._queue
+            thread = self._com_thread
+        queue.put(None)  # sentinel to unblock the worker
+        if thread and thread.is_alive():
+            thread.join(timeout=5.0)
         logger.info("COM worker thread stopped")
 
     def _wait_until_responsive(self, deadline: float) -> None:

--- a/src/utils/com_wrapper.py
+++ b/src/utils/com_wrapper.py
@@ -96,6 +96,26 @@ _BUSY_TIMEOUT_MESSAGE = (
 # Short on purpose: a recovery that goes well should be invisible, and one
 # that does not should not cost every later call another full timeout.
 _HEALTH_WAIT = 2.0
+_REBUILDING_MESSAGE = (
+    "PowerPoint stopped responding and the connection is being rebuilt. "
+    "Close any dialog open in PowerPoint, then retry."
+)
+# How long a caller waits for the worker to pick its operation up.  Time spent
+# in the queue is not the operation's own time, and charging it to the call
+# budget would misreport a healthy call that simply queued behind another one
+# (issue #192).  It also matters for #199: a call that spends its whole budget
+# queued cannot be told apart from a call the worker is stuck inside, and
+# treating it as a wedge would abandon a perfectly good worker and let a
+# replacement issue overlapping edits.
+#
+# Deliberately longer than one whole call budget, so a caller behind one slow
+# but healthy operation is served rather than taken back.
+_QUEUE_WAIT = 60.0
+_QUEUE_TIMEOUT_MESSAGE = (
+    "PowerPoint did not start the operation within %.0fs because earlier "
+    "operations were still running. It was cancelled rather than left to run "
+    "later." % _QUEUE_WAIT
+)
 # When True, the server sends ESC to PowerPoint on the first busy rejection to
 # dismiss any blocking modal dialog automatically.
 # Opt-in: set PPT_AUTO_DISMISS_DIALOG=true in mcp.json env to enable:
@@ -398,6 +418,7 @@ class PowerPointCOMWrapper:
                 break
             if item is not None:
                 item[3].cancel()
+                item[5].set()  # stop the caller waiting out the queue budget
         # If the abandoned worker ever does return from its call it goes back
         # to get().  The sentinel stops it blocking there for good.
         old_queue.put(None)
@@ -466,7 +487,13 @@ class PowerPointCOMWrapper:
                 item = queue.get()
                 if item is None:
                     break
-                func, args, kwargs, future, idempotent = item
+                func, args, kwargs, future, idempotent, dequeued = item
+                # The caller's own budget for the operation starts here, not
+                # when it was queued (issue #192).  Setting this on every path
+                # out of the queue, the drop below included, is what stops a
+                # caller waiting out the whole queue budget for an answer that
+                # already exists.
+                dequeued.set()
                 if generation != self._generation:
                     # Abandoned while this item sat in the queue, so it
                     # arrived after _recover_from_wedge had drained it.
@@ -510,20 +537,24 @@ class PowerPointCOMWrapper:
         Returns:
             The return value of func
 
+        The wait is in two parts.  Time spent queued behind other operations
+        belongs to the queue, not to this operation, so the call budget only
+        starts once the worker picks the item up (issue #192).  Keeping them
+        apart is also what makes a wedge identifiable at all: a call that used
+        up its budget waiting in line looks exactly like one the worker is
+        stuck inside, and abandoning the worker for it would be a bug.
+
         Raises:
             RuntimeError: if the COM worker thread has died, if a previous
                 call wedged it and the replacement has not reconnected yet,
-                or if the wait times out.
+                or if either wait times out.
             Any exception raised by func
         """
         if not self._healthy.wait(_HEALTH_WAIT):
             # A replacement worker is still probing.  Queueing here would
             # cost another full timeout to learn what is already known
             # (issue #199).
-            raise RuntimeError(
-                "PowerPoint stopped responding and the connection is being "
-                "rebuilt. Close any dialog open in PowerPoint, then retry."
-            )
+            raise RuntimeError(_REBUILDING_MESSAGE)
 
         if self._com_thread is not None and not self._com_thread.is_alive():
             # Nothing is draining the queue any more, so queueing would just
@@ -533,15 +564,29 @@ class PowerPointCOMWrapper:
                 "Restart the MCP server to reconnect to PowerPoint."
             )
 
-        # Read both once: recovery swaps the queue and bumps the generation,
-        # and this call has to be attributed to the one it was queued on.
-        generation = self._generation
-        queue = self._queue
         future: Future = Future()
-        queue.put((func, args, kwargs, future, idempotent))
+        dequeued = threading.Event()
+        # Under the recovery lock, so that the generation this call is
+        # attributed to and the queue it lands on are the same pair.  Without
+        # it a recovery could swap the queue in between, and the item would
+        # sit behind the sentinel on a queue no worker serves.
+        with self._recover_lock:
+            if not self._healthy.is_set():
+                # A recovery started while the health gate was being read.
+                raise RuntimeError(_REBUILDING_MESSAGE)
+            generation = self._generation
+            self._queue.put((func, args, kwargs, future, idempotent, dequeued))
         watching = pending_com_futures.get()
         if watching is not None:
             watching.add(future)
+
+        if not dequeued.wait(_QUEUE_WAIT):
+            # Still in the queue.  Take it back rather than let it run against
+            # a deck that has moved on, long after this call reported failure.
+            if future.cancel():
+                raise RuntimeError(_QUEUE_TIMEOUT_MESSAGE)
+            # It started in the moment the wait expired, so it gets its budget
+            # after all.
         # The worker may spend up to _BUSY_WAIT_BUDGET waiting for PowerPoint
         # before it even starts, so the caller has to allow for that on top of
         # the time the operation itself gets.  Otherwise the caller could
@@ -579,11 +624,13 @@ class PowerPointCOMWrapper:
                 # cancel; the caller may as well have the outcome.
                 return future.result()
 
-            # The future could be neither cancelled nor read, so the worker is
-            # inside the call and has been for the whole timeout.  That is the
-            # wedge, and only the call it is stuck on can tell.  Callers
-            # queued behind it cancel cleanly and must not trigger a second
-            # replacement.
+            # The future could be neither cancelled nor read, so the worker
+            # is inside the call and has been for the whole budget.  The
+            # budget started when the worker picked the item up, so this is
+            # time spent in the call and not in the queue, which is what makes
+            # it evidence of a wedge rather than of a busy worker.  Callers
+            # queued behind it cancel cleanly and must not each trigger
+            # another replacement.
             recovered = self._recover_from_wedge(generation)
             raise RuntimeError(
                 "PowerPoint did not finish the operation within %.0fs and it "

--- a/tests/test_busy_retry.py
+++ b/tests/test_busy_retry.py
@@ -14,6 +14,7 @@ while the budget still bounds the loops exactly as it would in production.
 from __future__ import annotations
 
 import sys
+import threading
 from concurrent.futures import Future
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -113,6 +114,17 @@ def test_mid_operation_busy_does_not_rerun_the_operation():
     assert func.call_count == 1, "the operation must not be repeated"
     with pytest.raises(RuntimeError, match="partially applied"):
         future.result()
+
+def _execute(w, *args, **kwargs):
+    """Call execute() as if the worker had picked the item up at once.
+
+    execute() waits for the dequeue before the call budget starts, so that
+    time spent queued behind other operations is not charged to the operation
+    (issue #192).  These tests run no worker and are about what happens once
+    the operation has started.
+    """
+    with patch.object(threading.Event, "wait", return_value=True):
+        return w.execute(*args, **kwargs)
 
 
 def test_idempotent_operation_is_retried_wholesale():
@@ -246,9 +258,10 @@ def test_execute_queues_the_idempotent_flag():
 
     # Don't start a COM thread — inspect what execute() put on the queue.
     with patch.object(Future, "result", return_value=None):
-        w.execute(func, 1, 2, idempotent=True, keyword="x")
+        _execute(w, func, 1, 2, idempotent=True, keyword="x")
 
-    queued_func, args, kwargs, _future, idempotent = w._queue.get_nowait()
+    queued_func, args, kwargs, _future, idempotent, _dequeued = \
+        w._queue.get_nowait()
     assert queued_func is func
     assert args == (1, 2)
     assert kwargs == {"keyword": "x"}, "idempotent must not leak into func kwargs"
@@ -258,8 +271,8 @@ def test_execute_queues_the_idempotent_flag():
 def test_execute_defaults_to_non_idempotent():
     w = PowerPointCOMWrapper()
     with patch.object(Future, "result", return_value=None):
-        w.execute(MagicMock())
-    *_, idempotent = w._queue.get_nowait()
+        _execute(w, MagicMock())
+    *_, idempotent, _dequeued = w._queue.get_nowait()
     assert idempotent is False
 
 
@@ -268,7 +281,7 @@ def test_execute_timeout_covers_the_busy_wait_as_well_as_the_call():
     spent its wait budget first, is still applying the edit."""
     w = PowerPointCOMWrapper()
     with patch.object(Future, "result", return_value=None) as result_mock:
-        w.execute(MagicMock())
+        _execute(w, MagicMock())
 
     timeout = result_mock.call_args.kwargs["timeout"]
     assert timeout == _BUSY_WAIT_BUDGET + _CALL_TIMEOUT

--- a/tests/test_queue_wait.py
+++ b/tests/test_queue_wait.py
@@ -1,0 +1,219 @@
+"""Waiting in the queue is not the operation's own time (issue #192).
+
+execute() used to give one combined budget to the whole wait, starting when
+the item was queued. Two things went wrong.
+
+A caller behind other operations was charged for time it spent in line, so a
+perfectly healthy call could be reported as failed while the worker had not
+even reached it, and the worker then ran it anyway against a deck that had
+moved on. On macOS the same shape produced duplicate pictures.
+
+It also made a wedge impossible to identify. A call that used up its budget
+queued looks exactly like one the worker is stuck inside, so the recovery
+added for #199 would abandon a healthy worker and let a replacement issue
+overlapping edits.
+
+So the wait is in two parts. The queue wait belongs to the queue and takes the
+operation back if it never starts; the call budget starts only once the worker
+picks the item up.
+
+No COM and no PowerPoint required.
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+import time
+from concurrent.futures import Future
+from pathlib import Path
+from queue import Queue
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_src_dir = str(Path(__file__).resolve().parents[1] / "src")
+if _src_dir not in sys.path:
+    sys.path.insert(0, _src_dir)
+
+from utils.com_wrapper import (  # noqa: E402
+    _BUSY_WAIT_BUDGET,
+    _CALL_TIMEOUT,
+    _QUEUE_WAIT,
+    PowerPointCOMWrapper,
+)
+
+
+def _wrapper(running=True):
+    w = PowerPointCOMWrapper()
+    w._running = running
+    return w
+
+
+# --- the budgets themselves -----------------------------------------------
+
+def test_the_queue_wait_outlasts_one_whole_call():
+    """Otherwise a caller behind a single slow but healthy operation is taken
+    back for no reason."""
+    assert _QUEUE_WAIT > _BUSY_WAIT_BUDGET + _CALL_TIMEOUT
+
+
+def test_the_two_waits_are_separate_budgets():
+    w = _wrapper()
+
+    with patch.object(threading.Event, "wait", return_value=True) as waited, \
+            patch.object(Future, "result", return_value=None) as result:
+        w.execute(MagicMock())
+
+    assert _QUEUE_WAIT in [call.args[0] for call in waited.call_args_list], (
+        "the dequeue is waited for with the queue budget"
+    )
+    assert result.call_args.kwargs["timeout"] == _BUSY_WAIT_BUDGET + _CALL_TIMEOUT, (
+        "and the operation still gets its whole budget afterwards"
+    )
+
+
+# --- an operation that never starts ---------------------------------------
+
+def test_an_operation_that_never_starts_is_taken_back():
+    """Reported as a failure and cancelled, so the worker skips it rather than
+    running it later against a deck that has moved on."""
+    w = _wrapper()
+
+    with patch("utils.com_wrapper._QUEUE_WAIT", 0.05), \
+            patch.object(PowerPointCOMWrapper, "_recover_from_wedge") as recover:
+        with pytest.raises(RuntimeError, match="did not start the operation"):
+            w.execute(MagicMock())
+
+    item = w._queue.get_nowait()
+    assert item[3].cancelled()
+    # A queue that is merely busy is not a wedge.
+    recover.assert_not_called()
+
+
+def test_the_queue_timeout_says_something():
+    """concurrent.futures.TimeoutError stringifies to the empty string, which
+    tools rendered as "Failed to add picture: " and nothing more."""
+    w = _wrapper()
+
+    with patch("utils.com_wrapper._QUEUE_WAIT", 0.05):
+        with pytest.raises(RuntimeError) as exc:
+            w.execute(MagicMock())
+
+    assert len(str(exc.value)) > 40
+
+
+def test_a_dequeue_that_wins_the_race_still_gets_its_budget():
+    """The wait expired, but the worker had just picked the item up, so the
+    cancel fails and the operation keeps its own budget."""
+    w = _wrapper()
+
+    with patch("utils.com_wrapper._QUEUE_WAIT", 0.01), \
+            patch.object(Future, "cancel", return_value=False), \
+            patch.object(Future, "result", return_value={"ok": True}) as result:
+        assert w.execute(MagicMock()) == {"ok": True}
+
+    assert result.call_args.kwargs["timeout"] == _BUSY_WAIT_BUDGET + _CALL_TIMEOUT
+
+
+# --- interaction with the wedge recovery ----------------------------------
+
+def test_time_spent_in_the_queue_is_not_read_as_a_wedge():
+    """The regression this guards. With one combined wait, an operation that
+    queued behind another for longer than a call budget was reported as a
+    wedge, and a healthy worker was abandoned while it kept mutating the
+    deck alongside its replacement."""
+    w = _wrapper(running=False)
+
+    class SlowQueue(Queue):
+        """Stands in for a worker busy with earlier operations."""
+
+        def get(self, *args, **kwargs):
+            item = super().get(*args, **kwargs)
+            time.sleep(0.4)  # longer than a whole call budget
+            return item
+
+    w._queue = SlowQueue()
+
+    with patch("utils.com_wrapper.pythoncom"), \
+            patch("utils.com_wrapper._BUSY_WAIT_BUDGET", 0.05), \
+            patch("utils.com_wrapper._CALL_TIMEOUT", 0.2), \
+            patch("utils.com_wrapper._QUEUE_WAIT", 5.0), \
+            patch.object(PowerPointCOMWrapper, "_recover_from_wedge") as recover:
+        w.start()
+        try:
+            assert w.execute(lambda: "served") == "served"
+        finally:
+            w.stop()
+
+    recover.assert_not_called()
+
+
+def test_recovery_releases_a_caller_still_waiting_in_the_queue():
+    w = _wrapper()
+    future: Future = Future()
+    dequeued = threading.Event()
+    w._queue.put((MagicMock(), (), {}, future, False, dequeued))
+
+    with patch.object(PowerPointCOMWrapper, "_start_worker"):
+        w._recover_from_wedge(0)
+
+    assert future.cancelled()
+    assert dequeued.is_set(), (
+        "otherwise the caller waits out the whole queue budget for an answer "
+        "that already exists"
+    )
+
+
+# --- picking the queue and the generation together ------------------------
+
+class _RecordingLock:
+    """A lock that says whether it is currently held."""
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self.held = False
+
+    def __enter__(self):
+        self._lock.acquire()
+        self.held = True
+        return self
+
+    def __exit__(self, *exc):
+        self.held = False
+        self._lock.release()
+
+
+def test_the_queue_is_chosen_under_the_recovery_lock():
+    """Recovery swaps the queue and bumps the generation together. Reading one
+    and putting on the other would leave the item behind the sentinel on a
+    queue no worker serves."""
+    w = _wrapper()
+    lock = _RecordingLock()
+    w._recover_lock = lock
+
+    class CheckingQueue(Queue):
+        def put(self, item, *args, **kwargs):
+            assert lock.held, (
+                "a recovery could swap the queue between the read and the put"
+            )
+            super().put(item, *args, **kwargs)
+
+    w._queue = CheckingQueue()
+
+    with patch.object(threading.Event, "wait", return_value=True), \
+            patch.object(Future, "result", return_value=None):
+        w.execute(MagicMock())
+
+
+def test_a_recovery_starting_while_the_gate_is_read_is_reported():
+    """The health gate is checked again under the lock, so a call cannot slip
+    onto a queue whose worker has just been abandoned."""
+    w = _wrapper()
+    w._healthy.clear()
+
+    with patch.object(threading.Event, "wait", return_value=True):
+        with pytest.raises(RuntimeError, match="being rebuilt"):
+            w.execute(MagicMock())
+
+    assert w._queue.empty()

--- a/tests/test_wedge_recovery.py
+++ b/tests/test_wedge_recovery.py
@@ -1,0 +1,297 @@
+"""Recovering from a COM worker stuck inside a call (issue #199).
+
+A COM call that never returns used to wedge the server for good.  Every later
+request queued behind the stuck worker and timed out, and only restarting the
+client made PowerPoint usable again.
+
+The worker cannot be reclaimed, because an outgoing COM call is not
+interruptible from this side.  So it is abandoned instead: the generation is
+bumped, a fresh STA worker takes over a fresh queue, and everything the stuck
+worker had not started is cancelled rather than applied minutes later.  While
+the replacement is still proving that PowerPoint answers, calls fail fast with
+an actionable message instead of each costing another full timeout.
+
+No COM and no PowerPoint required.
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+from concurrent.futures import Future, TimeoutError as FuturesTimeoutError
+from pathlib import Path
+from queue import Queue
+from unittest.mock import MagicMock, patch
+
+import pytest
+import pywintypes
+
+_src_dir = str(Path(__file__).resolve().parents[1] / "src")
+if _src_dir not in sys.path:
+    sys.path.insert(0, _src_dir)
+
+from utils.com_wrapper import PowerPointCOMWrapper  # noqa: E402
+
+# RPC_E_CALL_REJECTED — PowerPoint answering "busy", most likely a dialog.
+BUSY = -2147418111
+# MK_E_UNAVAILABLE — PowerPoint is not there at all.
+NOT_RUNNING = -2147221021
+
+
+def _com_error(hresult):
+    return pywintypes.com_error(hresult, "test", None, None)
+
+
+def _wrapper(running=True):
+    w = PowerPointCOMWrapper()
+    w._running = running
+    return w
+
+
+def _queued(future):
+    return (MagicMock(), (), {}, future, False)
+
+
+# --- deciding that the worker is wedged -----------------------------------
+
+def test_execute_replaces_the_worker_when_the_call_can_neither_be_cancelled_nor_read():
+    """The discriminator.  A future that will not cancel and is not done means
+    the worker is inside the call and has been for the whole timeout."""
+    w = _wrapper()
+
+    with patch.object(Future, "result", side_effect=FuturesTimeoutError), \
+            patch.object(Future, "cancel", return_value=False), \
+            patch.object(Future, "done", return_value=False), \
+            patch.object(PowerPointCOMWrapper, "_recover_from_wedge",
+                         return_value=True) as recover:
+        with pytest.raises(RuntimeError, match="fresh connection"):
+            w.execute(MagicMock())
+
+    recover.assert_called_once_with(0)
+
+
+def test_a_call_that_cancels_cleanly_does_not_replace_the_worker():
+    """Everything queued behind the stuck call cancels normally.  Those
+    callers must not each start another replacement."""
+    w = _wrapper()
+
+    with patch.object(Future, "result", side_effect=FuturesTimeoutError), \
+            patch.object(Future, "cancel", return_value=True), \
+            patch.object(PowerPointCOMWrapper, "_recover_from_wedge") as recover:
+        with pytest.raises(RuntimeError, match="was cancelled"):
+            w.execute(MagicMock())
+
+    recover.assert_not_called()
+
+
+def test_a_call_that_lands_during_the_timeout_race_is_still_returned():
+    w = _wrapper()
+
+    with patch.object(Future, "cancel", return_value=False), \
+            patch.object(Future, "done", return_value=True), \
+            patch.object(Future, "result",
+                         side_effect=[FuturesTimeoutError, {"ok": True}]), \
+            patch.object(PowerPointCOMWrapper, "_recover_from_wedge") as recover:
+        assert w.execute(MagicMock()) == {"ok": True}
+
+    recover.assert_not_called()
+
+
+# --- the replacement itself -----------------------------------------------
+
+def test_recovery_starts_a_new_worker_on_a_new_queue():
+    w = _wrapper()
+    old_queue = w._queue
+
+    with patch.object(PowerPointCOMWrapper, "_start_worker") as start:
+        assert w._recover_from_wedge(0) is True
+
+    assert w._generation == 1
+    assert w._queue is not old_queue, (
+        "the abandoned worker keeps its own queue, so the replacement needs a "
+        "fresh one or the stuck thread would drain it on unwedging"
+    )
+    start.assert_called_once_with(w._queue, 1)
+    assert not w._healthy.is_set()
+
+
+def test_only_the_first_caller_of_a_generation_recovers_it():
+    """Several callers can time out together on the same wedge."""
+    w = _wrapper()
+
+    with patch.object(PowerPointCOMWrapper, "_start_worker"):
+        assert w._recover_from_wedge(0) is True
+        assert w._recover_from_wedge(0) is False
+
+    assert w._generation == 1
+
+
+def test_recovery_cancels_the_work_the_stuck_worker_never_started():
+    w = _wrapper()
+    old_queue = w._queue
+    first, second = Future(), Future()
+    old_queue.put(_queued(first))
+    old_queue.put(_queued(second))
+
+    with patch.object(PowerPointCOMWrapper, "_start_worker"):
+        w._recover_from_wedge(0)
+
+    assert first.cancelled() and second.cancelled()
+    assert old_queue.get_nowait() is None, (
+        "a sentinel must be left behind, or a worker that unwedges blocks "
+        "forever in get() on a queue nobody feeds"
+    )
+
+
+def test_no_recovery_once_the_wrapper_is_stopping():
+    w = _wrapper(running=False)
+
+    with patch.object(PowerPointCOMWrapper, "_start_worker") as start:
+        assert w._recover_from_wedge(0) is False
+
+    start.assert_not_called()
+
+
+# --- the health gate ------------------------------------------------------
+
+def test_execute_fails_fast_while_the_replacement_is_still_probing():
+    w = _wrapper()
+    w._healthy.clear()
+
+    with patch("utils.com_wrapper._HEALTH_WAIT", 0.01):
+        with pytest.raises(RuntimeError, match="being rebuilt"):
+            w.execute(MagicMock())
+
+    assert w._queue.empty(), "nothing should be queued behind a wedge"
+
+
+def test_the_probe_reattaches_and_reopens_the_gate():
+    w = _wrapper()
+    w._generation = 1
+    w._healthy.clear()
+    app = MagicMock()
+
+    with patch("utils.com_wrapper.win32com.client.GetActiveObject",
+               return_value=app):
+        w._reattach_after_wedge(1)
+
+    assert w._app is app
+    assert w._healthy.is_set()
+
+
+def test_the_probe_keeps_the_gate_shut_while_powerpoint_is_still_busy():
+    """A busy rejection most likely means the dialog that caused the wedge is
+    still up.  Reporting health then would turn the next call into a
+    misleading "partially applied" error for work that never started."""
+    w = _wrapper()
+    w._generation = 1
+    w._healthy.clear()
+    app = MagicMock()
+
+    with patch("utils.com_wrapper.win32com.client.GetActiveObject",
+               side_effect=[_com_error(BUSY), _com_error(BUSY), app]), \
+            patch("utils.com_wrapper.time.sleep") as sleep:
+        w._reattach_after_wedge(1)
+
+    assert sleep.call_count == 2
+    assert w._app is app
+    assert w._healthy.is_set()
+
+
+def test_the_probe_gives_up_on_anything_that_is_not_busy():
+    """PowerPoint being absent is not a reason to stay shut.  _connect_impl
+    relaunches it the way it always has."""
+    w = _wrapper()
+    w._generation = 1
+    w._healthy.clear()
+
+    with patch("utils.com_wrapper.win32com.client.GetActiveObject",
+               side_effect=_com_error(NOT_RUNNING)):
+        w._reattach_after_wedge(1)
+
+    assert w._app is None
+    assert w._healthy.is_set()
+
+
+def test_the_probe_drops_the_proxy_the_wedged_worker_held():
+    """It belongs to an apartment this thread cannot call into."""
+    w = _wrapper()
+    w._generation = 1
+    w._app = MagicMock(name="proxy from the dead apartment")
+
+    with patch("utils.com_wrapper.win32com.client.GetActiveObject",
+               side_effect=_com_error(NOT_RUNNING)):
+        w._reattach_after_wedge(1)
+
+    assert w._app is None
+
+
+# --- what the abandoned worker may and may not do -------------------------
+
+def test_an_abandoned_worker_leaves_the_live_connection_alone():
+    """Its finally clause must not clear the app its replacement is using."""
+    w = _wrapper()
+    live_app = MagicMock()
+    w._app = live_app
+    w._generation = 1  # this worker is generation 0, so it has been replaced
+
+    with patch("utils.com_wrapper.pythoncom"):
+        w._com_worker(Queue(), 0)
+
+    assert w._app is live_app
+
+
+def test_an_abandoned_worker_drops_an_item_that_arrives_late():
+    """Recovery drains the old queue, but the worker may pick something up in
+    the gap.  It must be cancelled, not run."""
+    w = _wrapper()
+    future: Future = Future()
+
+    class BumpOnGet(Queue):
+        def get(self, *args, **kwargs):
+            item = super().get(*args, **kwargs)
+            w._generation += 1  # abandoned while this item sat in the queue
+            return item
+
+    queue = BumpOnGet()
+    queue.put(_queued(future))
+
+    with patch("utils.com_wrapper.pythoncom"), \
+            patch.object(PowerPointCOMWrapper, "_run_item") as run_item:
+        w._com_worker(queue, 0)
+
+    run_item.assert_not_called()
+    assert future.cancelled()
+
+
+# --- end to end, with real threads ----------------------------------------
+
+def test_the_next_call_is_served_after_a_wedge():
+    """The whole point of the exercise.  One stuck call used to end the
+    session; now the operation after it goes through."""
+    w = _wrapper(running=False)
+    entered = threading.Event()
+    release = threading.Event()
+
+    def stuck():
+        entered.set()
+        release.wait(10)
+
+    app = MagicMock()
+
+    with patch("utils.com_wrapper.pythoncom"), \
+            patch("utils.com_wrapper.win32com.client.GetActiveObject",
+                  return_value=app), \
+            patch("utils.com_wrapper._BUSY_WAIT_BUDGET", 0.05), \
+            patch("utils.com_wrapper._CALL_TIMEOUT", 0.25):
+        w.start()
+        try:
+            with pytest.raises(RuntimeError, match="fresh connection"):
+                w.execute(stuck)
+
+            assert entered.is_set(), "the worker really was inside the call"
+            assert w._generation == 1
+            assert w.execute(lambda: "served") == "served"
+        finally:
+            release.set()
+            w.stop()

--- a/tests/test_wedge_recovery.py
+++ b/tests/test_wedge_recovery.py
@@ -42,6 +42,18 @@ def _com_error(hresult):
     return pywintypes.com_error(hresult, "test", None, None)
 
 
+def _execute(w, *args, **kwargs):
+    """Call execute() as if the worker had picked the item up at once.
+
+    execute() waits for the dequeue before the call budget starts, so that
+    time spent queued behind other operations is not charged to the operation
+    (issue #192).  These tests run no worker and are about what happens once
+    the operation has started.
+    """
+    with patch.object(threading.Event, "wait", return_value=True):
+        return w.execute(*args, **kwargs)
+
+
 def _wrapper(running=True):
     w = PowerPointCOMWrapper()
     w._running = running
@@ -49,7 +61,7 @@ def _wrapper(running=True):
 
 
 def _queued(future):
-    return (MagicMock(), (), {}, future, False)
+    return (MagicMock(), (), {}, future, False, threading.Event())
 
 
 # --- deciding that the worker is wedged -----------------------------------
@@ -65,7 +77,7 @@ def test_execute_replaces_the_worker_when_the_call_can_neither_be_cancelled_nor_
             patch.object(PowerPointCOMWrapper, "_recover_from_wedge",
                          return_value=True) as recover:
         with pytest.raises(RuntimeError, match="fresh connection"):
-            w.execute(MagicMock())
+            _execute(w, MagicMock())
 
     recover.assert_called_once_with(0)
 
@@ -79,7 +91,7 @@ def test_a_call_that_cancels_cleanly_does_not_replace_the_worker():
             patch.object(Future, "cancel", return_value=True), \
             patch.object(PowerPointCOMWrapper, "_recover_from_wedge") as recover:
         with pytest.raises(RuntimeError, match="was cancelled"):
-            w.execute(MagicMock())
+            _execute(w, MagicMock())
 
     recover.assert_not_called()
 
@@ -92,7 +104,7 @@ def test_a_call_that_lands_during_the_timeout_race_is_still_returned():
             patch.object(Future, "result",
                          side_effect=[FuturesTimeoutError, {"ok": True}]), \
             patch.object(PowerPointCOMWrapper, "_recover_from_wedge") as recover:
-        assert w.execute(MagicMock()) == {"ok": True}
+        assert _execute(w, MagicMock()) == {"ok": True}
 
     recover.assert_not_called()
 

--- a/tests/test_wedge_recovery.py
+++ b/tests/test_wedge_recovery.py
@@ -307,3 +307,59 @@ def test_the_next_call_is_served_after_a_wedge():
         finally:
             release.set()
             w.stop()
+
+
+# --- deliberate shutdown and restart --------------------------------------
+
+class _CountingLock:
+    """A lock that says how many times it has been taken."""
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self.entered = 0
+
+    def __enter__(self):
+        self._lock.acquire()
+        self.entered += 1
+        return self
+
+    def __exit__(self, *exc):
+        self._lock.release()
+
+
+def test_stop_reads_the_live_worker_under_the_recovery_lock():
+    """A wedge confirmed at this exact moment would otherwise swap the queue
+    and the thread in between, leaving the sentinel on the abandoned queue and
+    the live worker running while stop() reported success."""
+    w = _wrapper()
+    lock = _CountingLock()
+    w._recover_lock = lock
+    thread = MagicMock()
+    thread.is_alive.return_value = False
+    w._com_thread = thread
+
+    w.stop()
+
+    assert lock.entered == 1
+    assert w._queue.get_nowait() is None, "the sentinel goes to the live queue"
+    assert not w._running
+
+
+def test_a_deliberate_restart_is_not_treated_as_a_recovery():
+    """Generation 0 skips the reattach probe, so a restart that catches
+    PowerPoint busy behaves like a normal start rather than inheriting the
+    unbounded wait meant for a wedge."""
+    w = _wrapper(running=False)
+    w._generation = 3
+    stale = w._queue
+    stale.put(None)  # the sentinel left behind by the previous stop
+
+    with patch.object(PowerPointCOMWrapper, "_start_worker") as start:
+        w.start()
+
+    assert w._generation == 0
+    assert w._queue is not stale, (
+        "a leftover sentinel would stop the new worker the moment it started"
+    )
+    start.assert_called_once_with(w._queue, 0)
+    assert w._healthy.is_set()

--- a/tests/test_worker_liveness.py
+++ b/tests/test_worker_liveness.py
@@ -17,6 +17,7 @@ No COM and no PowerPoint required.
 from __future__ import annotations
 
 import sys
+import threading
 from concurrent.futures import Future, TimeoutError as FuturesTimeoutError
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -44,6 +45,17 @@ def test_cancelled_operation_is_not_run():
     w._run_item(func, (), {}, future, False)
 
     func.assert_not_called()
+
+def _execute(w, *args, **kwargs):
+    """Call execute() as if the worker had picked the item up at once.
+
+    execute() waits for the dequeue before the call budget starts, so that
+    time spent queued behind other operations is not charged to the operation
+    (issue #192).  These tests run no worker and are about what happens once
+    the operation has started.
+    """
+    with patch.object(threading.Event, "wait", return_value=True):
+        return w.execute(*args, **kwargs)
 
 
 def test_running_operation_can_no_longer_be_cancelled():
@@ -103,7 +115,7 @@ def test_timeout_error_raised_by_the_operation_is_not_mistaken_for_ours():
          patch.object(Future, "done", return_value=True), \
          patch.object(Future, "cancel") as cancel_mock:
         with pytest.raises(TimeoutError, match="COM call timed out"):
-            w.execute(MagicMock())
+            _execute(w, MagicMock())
 
     # A finished future must not be cancelled.
     cancel_mock.assert_not_called()
@@ -115,7 +127,7 @@ def test_execute_cancels_the_future_when_it_times_out():
     with patch.object(Future, "result", side_effect=FuturesTimeoutError), \
          patch.object(Future, "cancel", return_value=True) as cancel_mock:
         with pytest.raises(RuntimeError, match="cancelled"):
-            w.execute(MagicMock())
+            _execute(w, MagicMock())
 
     cancel_mock.assert_called_once()
 
@@ -128,7 +140,7 @@ def test_execute_says_so_when_the_operation_could_not_be_cancelled():
     with patch.object(Future, "result", side_effect=FuturesTimeoutError), \
          patch.object(Future, "cancel", return_value=False):
         with pytest.raises(RuntimeError, match="may still be applied"):
-            w.execute(MagicMock())
+            _execute(w, MagicMock())
 
 
 def test_timeout_does_not_leak_a_bare_futures_timeout():
@@ -138,7 +150,7 @@ def test_timeout_does_not_leak_a_bare_futures_timeout():
     with patch.object(Future, "result", side_effect=FuturesTimeoutError), \
          patch.object(Future, "done", return_value=False):
         with pytest.raises(RuntimeError) as exc:
-            w.execute(MagicMock())
+            _execute(w, MagicMock())
 
     assert "PowerPoint did not finish" in str(exc.value)
 
@@ -200,7 +212,7 @@ def test_worker_loop_survives_an_item_that_escapes_run_item():
     w = PowerPointCOMWrapper()
     w._running = True
     future: Future = Future()
-    w._queue.put((MagicMock(), (), {}, future, False))
+    w._queue.put((MagicMock(), (), {}, future, False, threading.Event()))
     w._queue.put(None)  # sentinel so the loop exits after the bad item
 
     with patch("utils.com_wrapper.pythoncom"):
@@ -223,7 +235,7 @@ def test_execute_returns_the_result_if_it_lands_during_the_timeout_race():
                 Future, "result",
                 side_effect=[FuturesTimeoutError, {"ok": True}],
             ):
-                assert w.execute(MagicMock()) == {"ok": True}
+                assert _execute(w, MagicMock()) == {"ok": True}
 
 
 def test_execute_fails_fast_when_the_worker_thread_is_dead():
@@ -233,7 +245,7 @@ def test_execute_fails_fast_when_the_worker_thread_is_dead():
     w._com_thread = dead
 
     with pytest.raises(RuntimeError, match="no longer running"):
-        w.execute(MagicMock())
+        _execute(w, MagicMock())
 
     assert w._queue.empty(), "nothing should be queued for a dead worker"
 
@@ -246,7 +258,7 @@ def test_execute_still_queues_while_the_worker_is_alive():
     func = MagicMock()
 
     with patch.object(Future, "result", return_value=None):
-        w.execute(func)
+        _execute(w, func)
 
     queued_func, *_ = w._queue.get_nowait()
     assert queued_func is func

--- a/tests/test_worker_liveness.py
+++ b/tests/test_worker_liveness.py
@@ -206,7 +206,7 @@ def test_worker_loop_survives_an_item_that_escapes_run_item():
     with patch("utils.com_wrapper.pythoncom"):
         with patch.object(PowerPointCOMWrapper, "_run_item",
                           side_effect=RuntimeError("escaped")):
-            w._com_worker()
+            w._com_worker(w._queue, 0)
 
     assert future.done(), "the caller must not be left waiting forever"
     with pytest.raises(RuntimeError, match="COM worker failed"):

--- a/uv.lock
+++ b/uv.lock
@@ -390,7 +390,7 @@ wheels = [
 
 [[package]]
 name = "ppt-mcp"
-version = "1.8.0"
+version = "1.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
Closes #199

Last piece of #199, after cancelling abandoned futures and the liveness check shipped in v1.8.0.

## The problem

A COM call that never returns wedges the server permanently. Every later request queues behind the stuck worker and times out after the full budget, and only restarting the client makes PowerPoint usable again. That is the freeze reported in #183.

Calls that can hang rather than answer "busy" include `chart.ChartData.Activate()` (it starts Excel, which can stall on a first-run or licensing dialog), `Presentations.Open` and `SaveAs` behind a "file in use" or password prompt, and clipboard round-trips.

## What this does

The stuck thread cannot be reclaimed. An outgoing COM call is not interruptible from this side, and `CoCancelCall` needs server-side cooperation that PowerPoint does not provide. So the thread is abandoned instead.

1. The worker generation is bumped and a fresh STA worker takes over a fresh queue. Each worker now owns the queue it was started with, so a worker that unwedges later cannot drain the queue its replacement is serving.
2. Everything the stuck worker had not started is cancelled, so nothing lands minutes after the caller was told it had failed. A sentinel is left on the old queue so an unwedging worker does not block forever in `get()`.
3. The replacement probes `GetActiveObject` before serving traffic. Until it answers, calls fail fast with "PowerPoint stopped responding and the connection is being rebuilt. Close any dialog open in PowerPoint, then retry." rather than each costing another timeout.
4. An abandoned worker leaves shared state alone. It does not clear `self._app` on the way out and does not run late arrivals.

## Deciding that the worker is wedged

Only the call the worker is actually stuck on triggers a replacement. Its future can be neither cancelled nor read after the whole timeout, which means the worker is inside it. Everything queued behind it cancels cleanly, so one wedge produces one replacement however many callers time out together.

## Trade-offs, stated plainly

* One daemon thread is leaked per wedge, along with the COM proxy it holds. That is the price of turning "only a client restart fixes this" into "you get an error and the next operation works".
* A slow but healthy operation that crosses 45s is indistinguishable from a wedge from the outside. It gets replaced too, and the abandoned worker may still apply the edit. The error says so.
* A busy rejection during the probe keeps the gate shut and keeps probing. Reporting health there would turn the next call into a misleading "partially applied" error for work that never started. Any other failure opens the gate so `_connect_impl` can relaunch PowerPoint as it always has.

## Testing

15 new tests in `tests/test_wedge_recovery.py`, 667 in total, no COM and no PowerPoint required. The last one runs real threads end to end and asserts that the operation after a stuck call goes through.

A genuine COM hang cannot be forced on demand, so the state machine is unit-tested and the live check is that ordinary operation still works after the refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VwK4mAj3ZmXKNqjzJZZhZ8
